### PR TITLE
Auto/refresh query options and blip saving

### DIFF
--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -260,9 +260,9 @@
 				6E0EEE892037299700F38EE1 /* MapAccessoryView.swift */,
 				6ECD61F4203E755800E6068F /* MapRefreshButton.swift */,
 				6E71ED3E202621FE00EC17B9 /* MapViewController.swift */,
+				6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
-				6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -270,12 +270,12 @@
 		6E97D2992023CD9100DD8368 /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
-				6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */,
 				6E6BAE0F202A5BEA0087FD92 /* AttractionTableObserver.swift */,
 				6ECE5E5A2030B35C00886884 /* BlipObserver.swift */,
 				6E97D2722023CD4B00DD8368 /* LocationObserver.swift */,
 				6EA4065320265FED009069F4 /* LookupModelObserver.swift */,
 				6E71ED3C2026213F00EC17B9 /* MapModelObserver.swift */,
+				6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */,
 				6E97D2752023CD4C00DD8368 /* ServerInterface.swift */,
 				6E97D2742023CD4C00DD8368 /* UserAccountObserver.swift */,
 				6E97D2732023CD4B00DD8368 /* UserHistoryObserver.swift */,
@@ -802,6 +802,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = FY36VGL2Q2;
 				INFOPLIST_FILE = BlipsClientUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fourth.BlipsClientUITests;
@@ -817,6 +818,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = FY36VGL2Q2;
 				INFOPLIST_FILE = BlipsClientUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fourth.BlipsClientUITests;

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */; };
 		6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28F2023CD6100DD8368 /* SignInViewController.swift */; };
 		6E9E56822042241A0076C88F /* BlipDetailObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E56812042241A0076C88F /* BlipDetailObserver.swift */; };
+		6E9E5684204282640076C88F /* SavedBlipTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */; };
 		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
 		6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
@@ -123,6 +124,7 @@
 		6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewController.swift; sourceTree = "<group>"; };
 		6E97D28F2023CD6100DD8368 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		6E9E56812042241A0076C88F /* BlipDetailObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlipDetailObserver.swift; sourceTree = "<group>"; };
+		6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBlipTableViewController.swift; sourceTree = "<group>"; };
 		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsObserver.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
@@ -267,6 +269,7 @@
 				6ECD61F4203E755800E6068F /* MapRefreshButton.swift */,
 				6E71ED3E202621FE00EC17B9 /* MapViewController.swift */,
 				6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */,
+				6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
 			);
@@ -277,6 +280,7 @@
 			isa = PBXGroup;
 			children = (
 				6E6BAE0F202A5BEA0087FD92 /* AttractionTableObserver.swift */,
+				6E9E56812042241A0076C88F /* BlipDetailObserver.swift */,
 				6ECE5E5A2030B35C00886884 /* BlipObserver.swift */,
 				6E97D2722023CD4B00DD8368 /* LocationObserver.swift */,
 				6EA4065320265FED009069F4 /* LookupModelObserver.swift */,
@@ -285,7 +289,6 @@
 				6E97D2752023CD4C00DD8368 /* ServerInterface.swift */,
 				6E97D2742023CD4C00DD8368 /* UserAccountObserver.swift */,
 				6E97D2732023CD4B00DD8368 /* UserHistoryObserver.swift */,
-				6E9E56812042241A0076C88F /* BlipDetailObserver.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -546,6 +549,7 @@
 				6E97D2782023CD4C00DD8368 /* UserAccountObserver.swift in Sources */,
 				6E97D2902023CD6100DD8368 /* AttributesTableViewController.swift in Sources */,
 				6ECE5E5B2030B35C00886884 /* BlipObserver.swift in Sources */,
+				6E9E5684204282640076C88F /* SavedBlipTableViewController.swift in Sources */,
 				6EA84DBD2040DF2E008C40A6 /* AutoQueryOptions.swift in Sources */,
 				6E18824E202CEF5000061C67 /* AnywhereUIAlertController.swift in Sources */,
 				6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		6EF0C66D2013A9C300C967C6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6EF0C66C2013A9C300C967C6 /* GoogleService-Info.plist */; };
 		6EF0C66E2013AA0100C967C6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6EF0C66C2013A9C300C967C6 /* GoogleService-Info.plist */; };
 		6EF0C66F2013AA0100C967C6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6EF0C66C2013A9C300C967C6 /* GoogleService-Info.plist */; };
+		6EF807392048EE5B00FABFB5 /* SavedBlipTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF807382048EE5B00FABFB5 /* SavedBlipTableViewCell.swift */; };
 		C24D87B1193601577C95E75D /* Pods_BlipsClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 05A60F4C5F6F59B26C13F533 /* Pods_BlipsClient.framework */; };
 /* End PBXBuildFile section */
 
@@ -144,6 +145,7 @@
 		6EE12FD02024C71400509452 /* MainModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainModel.swift; sourceTree = "<group>"; };
 		6EE12FD22024C73E00509452 /* MapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
 		6EF0C66C2013A9C300C967C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		6EF807382048EE5B00FABFB5 /* SavedBlipTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBlipTableViewCell.swift; sourceTree = "<group>"; };
 		B11E4D0B8AFEA76033DF6A5A /* Pods-BlipsClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlipsClient.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BlipsClient/Pods-BlipsClient.debug.xcconfig"; sourceTree = "<group>"; };
 		F5C68D005D8613419F09CE03 /* Pods-BlipsClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BlipsClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-BlipsClient/Pods-BlipsClient.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -274,6 +276,7 @@
 				6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
+				6EF807382048EE5B00FABFB5 /* SavedBlipTableViewCell.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -564,6 +567,7 @@
 				6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */,
 				6E97D2772023CD4C00DD8368 /* UserHistoryObserver.swift in Sources */,
 				6EE12FD32024C73E00509452 /* MapModel.swift in Sources */,
+				6EF807392048EE5B00FABFB5 /* SavedBlipTableViewCell.swift in Sources */,
 				6EDE4DE6202E971500E80AF7 /* BlipDetailViewController.swift in Sources */,
 				6E0EEE8A2037299700F38EE1 /* MapAccessoryView.swift in Sources */,
 				6ECE91942027B5EB009CAC91 /* BlipMarkerView.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */; };
 		6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28F2023CD6100DD8368 /* SignInViewController.swift */; };
 		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
+		6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
 		6EAD4E831FBB8748003C2E30 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */; };
 		6ECD61F3203E6A8D00E6068F /* refresh.png in Resources */ = {isa = PBXBuildFile; fileRef = 6ECD61F2203E6A8C00E6068F /* refresh.png */; };
@@ -119,6 +120,7 @@
 		6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewController.swift; sourceTree = "<group>"; };
 		6E97D28F2023CD6100DD8368 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
+		6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsObserver.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
 		6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		6ECD61F2203E6A8C00E6068F /* refresh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = refresh.png; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 		6E97D2992023CD9100DD8368 /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
+				6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */,
 				6E6BAE0F202A5BEA0087FD92 /* AttractionTableObserver.swift */,
 				6ECE5E5A2030B35C00886884 /* BlipObserver.swift */,
 				6E97D2722023CD4B00DD8368 /* LocationObserver.swift */,
@@ -535,6 +538,7 @@
 				6E97D2902023CD6100DD8368 /* AttributesTableViewController.swift in Sources */,
 				6ECE5E5B2030B35C00886884 /* BlipObserver.swift in Sources */,
 				6E18824E202CEF5000061C67 /* AnywhereUIAlertController.swift in Sources */,
+				6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */,
 				6E97D2792023CD4C00DD8368 /* ServerInterface.swift in Sources */,
 				6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */,
 				6ECE5E5D20311DAB00886884 /* BlipTableViewController.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		6E97D2952023CD6100DD8368 /* AttractionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28D2023CD6000DD8368 /* AttractionsTableViewCell.swift */; };
 		6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */; };
 		6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28F2023CD6100DD8368 /* SignInViewController.swift */; };
+		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
 		6EAD4E831FBB8748003C2E30 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */; };
 		6ECD61F3203E6A8D00E6068F /* refresh.png in Resources */ = {isa = PBXBuildFile; fileRef = 6ECD61F2203E6A8C00E6068F /* refresh.png */; };
@@ -117,6 +118,7 @@
 		6E97D28D2023CD6000DD8368 /* AttractionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewCell.swift; sourceTree = "<group>"; };
 		6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewController.swift; sourceTree = "<group>"; };
 		6E97D28F2023CD6100DD8368 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
+		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
 		6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		6ECD61F2203E6A8C00E6068F /* refresh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = refresh.png; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				6E71ED3E202621FE00EC17B9 /* MapViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
+				6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 				6ECE5E5B2030B35C00886884 /* BlipObserver.swift in Sources */,
 				6E18824E202CEF5000061C67 /* AnywhereUIAlertController.swift in Sources */,
 				6E97D2792023CD4C00DD8368 /* ServerInterface.swift in Sources */,
+				6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */,
 				6ECE5E5D20311DAB00886884 /* BlipTableViewController.swift in Sources */,
 				6E1B877F2030A8180004E364 /* BlipPhotoViewController.swift in Sources */,
 				6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		6E2086421FA2100F00C824D9 /* BlipsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2086411FA2100F00C824D9 /* BlipsClientTests.swift */; };
 		6E20864D1FA2100F00C824D9 /* BlipsClientUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20864C1FA2100F00C824D9 /* BlipsClientUITests.swift */; };
 		6E20865D1FA2106100C824D9 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E20865C1FA2106100C824D9 /* MapKit.framework */; };
+		6E5A8D3D203F6E8F006F1C59 /* AccountOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5A8D3C203F6E8F006F1C59 /* AccountOptionsTableViewController.swift */; };
 		6E6BAE10202A5BEA0087FD92 /* AttractionTableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6BAE0F202A5BEA0087FD92 /* AttractionTableObserver.swift */; };
 		6E71ED3D2026213F00EC17B9 /* MapModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E71ED3C2026213F00EC17B9 /* MapModelObserver.swift */; };
 		6E71ED3F202621FE00EC17B9 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E71ED3E202621FE00EC17B9 /* MapViewController.swift */; };
@@ -33,7 +34,6 @@
 		6E97D2862023CD5800DD8368 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D27F2023CD5600DD8368 /* User.swift */; };
 		6E97D2872023CD5800DD8368 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2802023CD5700DD8368 /* Location.swift */; };
 		6E97D2902023CD6100DD8368 /* AttributesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2882023CD5E00DD8368 /* AttributesTableViewController.swift */; };
-		6E97D2912023CD6100DD8368 /* AccountOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */; };
 		6E97D2922023CD6100DD8368 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28A2023CD5F00DD8368 /* AccountViewController.swift */; };
 		6E97D2932023CD6100DD8368 /* LookupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28B2023CD5F00DD8368 /* LookupViewController.swift */; };
 		6E97D2942023CD6100DD8368 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28C2023CD6000DD8368 /* ViewController.swift */; };
@@ -95,6 +95,7 @@
 		6E20864E1FA2100F00C824D9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6E20865A1FA2105900C824D9 /* BlipsClient.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BlipsClient.entitlements; sourceTree = "<group>"; };
 		6E20865C1FA2106100C824D9 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
+		6E5A8D3C203F6E8F006F1C59 /* AccountOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6E6BAE0F202A5BEA0087FD92 /* AttractionTableObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionTableObserver.swift; sourceTree = "<group>"; };
 		6E71ED3C2026213F00EC17B9 /* MapModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModelObserver.swift; sourceTree = "<group>"; };
 		6E71ED3E202621FE00EC17B9 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
@@ -110,7 +111,6 @@
 		6E97D27F2023CD5600DD8368 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		6E97D2802023CD5700DD8368 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		6E97D2882023CD5E00DD8368 /* AttributesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesTableViewController.swift; sourceTree = "<group>"; };
-		6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountOptionsViewController.swift; sourceTree = "<group>"; };
 		6E97D28A2023CD5F00DD8368 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
 		6E97D28B2023CD5F00DD8368 /* LookupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupViewController.swift; sourceTree = "<group>"; };
 		6E97D28C2023CD6000DD8368 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -240,6 +240,7 @@
 		6E97D2982023CD7500DD8368 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				6E5A8D3C203F6E8F006F1C59 /* AccountOptionsTableViewController.swift */,
 				6E97D28A2023CD5F00DD8368 /* AccountViewController.swift */,
 				6E18824D202CEF5000061C67 /* AnywhereUIAlertController.swift */,
 				6E97D28D2023CD6000DD8368 /* AttractionsTableViewCell.swift */,
@@ -256,7 +257,6 @@
 				6ECD61F4203E755800E6068F /* MapRefreshButton.swift */,
 				6E71ED3E202621FE00EC17B9 /* MapViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
-				6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
 			);
 			path = Controllers;
@@ -549,6 +549,7 @@
 				6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */,
 				6E97D2762023CD4C00DD8368 /* LocationObserver.swift in Sources */,
 				6E20862D1FA2100F00C824D9 /* AppDelegate.swift in Sources */,
+				6E5A8D3D203F6E8F006F1C59 /* AccountOptionsTableViewController.swift in Sources */,
 				6E97D2942023CD6100DD8368 /* ViewController.swift in Sources */,
 				6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */,
 				6E6BAE10202A5BEA0087FD92 /* AttractionTableObserver.swift in Sources */,
@@ -561,7 +562,6 @@
 				6EE12FD12024C71400509452 /* MainModel.swift in Sources */,
 				6E97D2932023CD6100DD8368 /* LookupViewController.swift in Sources */,
 				6E97D2952023CD6100DD8368 /* AttractionsTableViewCell.swift in Sources */,
-				6E97D2912023CD6100DD8368 /* AccountOptionsViewController.swift in Sources */,
 				6E71ED3D2026213F00EC17B9 /* MapModelObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28F2023CD6100DD8368 /* SignInViewController.swift */; };
 		6E9E56822042241A0076C88F /* BlipDetailObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E56812042241A0076C88F /* BlipDetailObserver.swift */; };
 		6E9E5684204282640076C88F /* SavedBlipTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */; };
+		6E9E568620428A540076C88F /* SavedBlipTableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E568520428A540076C88F /* SavedBlipTableObserver.swift */; };
 		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
 		6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
@@ -125,6 +126,7 @@
 		6E97D28F2023CD6100DD8368 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		6E9E56812042241A0076C88F /* BlipDetailObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlipDetailObserver.swift; sourceTree = "<group>"; };
 		6E9E5683204282640076C88F /* SavedBlipTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBlipTableViewController.swift; sourceTree = "<group>"; };
+		6E9E568520428A540076C88F /* SavedBlipTableObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedBlipTableObserver.swift; sourceTree = "<group>"; };
 		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsObserver.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				6EA4065320265FED009069F4 /* LookupModelObserver.swift */,
 				6E71ED3C2026213F00EC17B9 /* MapModelObserver.swift */,
 				6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */,
+				6E9E568520428A540076C88F /* SavedBlipTableObserver.swift */,
 				6E97D2752023CD4C00DD8368 /* ServerInterface.swift */,
 				6E97D2742023CD4C00DD8368 /* UserAccountObserver.swift */,
 				6E97D2732023CD4B00DD8368 /* UserHistoryObserver.swift */,
@@ -566,6 +569,7 @@
 				6ECE91942027B5EB009CAC91 /* BlipMarkerView.swift in Sources */,
 				6EA84DBB2040DF05008C40A6 /* AttractionHistory.swift in Sources */,
 				6E00C50D2037771300026E31 /* BlipTableToggleButton.swift in Sources */,
+				6E9E568620428A540076C88F /* SavedBlipTableObserver.swift in Sources */,
 				6ECE5E5F2031275800886884 /* BlipTableViewCell.swift in Sources */,
 				6E71ED3F202621FE00EC17B9 /* MapViewController.swift in Sources */,
 				6E97D2822023CD5800DD8368 /* CustomLookup.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		6E97D2952023CD6100DD8368 /* AttractionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28D2023CD6000DD8368 /* AttractionsTableViewCell.swift */; };
 		6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */; };
 		6E97D2972023CD6100DD8368 /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28F2023CD6100DD8368 /* SignInViewController.swift */; };
+		6E9E56822042241A0076C88F /* BlipDetailObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9E56812042241A0076C88F /* BlipDetailObserver.swift */; };
 		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
 		6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
@@ -121,6 +122,7 @@
 		6E97D28D2023CD6000DD8368 /* AttractionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewCell.swift; sourceTree = "<group>"; };
 		6E97D28E2023CD6000DD8368 /* AttractionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionsTableViewController.swift; sourceTree = "<group>"; };
 		6E97D28F2023CD6100DD8368 /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
+		6E9E56812042241A0076C88F /* BlipDetailObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlipDetailObserver.swift; sourceTree = "<group>"; };
 		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsObserver.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				6E97D2752023CD4C00DD8368 /* ServerInterface.swift */,
 				6E97D2742023CD4C00DD8368 /* UserAccountObserver.swift */,
 				6E97D2732023CD4B00DD8368 /* UserHistoryObserver.swift */,
+				6E9E56812042241A0076C88F /* BlipDetailObserver.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -548,6 +551,7 @@
 				6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */,
 				6E97D2792023CD4C00DD8368 /* ServerInterface.swift in Sources */,
 				6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */,
+				6E9E56822042241A0076C88F /* BlipDetailObserver.swift in Sources */,
 				6ECE5E5D20311DAB00886884 /* BlipTableViewController.swift in Sources */,
 				6E1B877F2030A8180004E364 /* BlipPhotoViewController.swift in Sources */,
 				6E97D2962023CD6100DD8368 /* AttractionsTableViewController.swift in Sources */,

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		6E97D2862023CD5800DD8368 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D27F2023CD5600DD8368 /* User.swift */; };
 		6E97D2872023CD5800DD8368 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2802023CD5700DD8368 /* Location.swift */; };
 		6E97D2902023CD6100DD8368 /* AttributesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2882023CD5E00DD8368 /* AttributesTableViewController.swift */; };
-		6E97D2912023CD6100DD8368 /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2892023CD5E00DD8368 /* StatisticsViewController.swift */; };
+		6E97D2912023CD6100DD8368 /* AccountOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */; };
 		6E97D2922023CD6100DD8368 /* AccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28A2023CD5F00DD8368 /* AccountViewController.swift */; };
 		6E97D2932023CD6100DD8368 /* LookupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28B2023CD5F00DD8368 /* LookupViewController.swift */; };
 		6E97D2942023CD6100DD8368 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E97D28C2023CD6000DD8368 /* ViewController.swift */; };
@@ -110,7 +110,7 @@
 		6E97D27F2023CD5600DD8368 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		6E97D2802023CD5700DD8368 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		6E97D2882023CD5E00DD8368 /* AttributesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributesTableViewController.swift; sourceTree = "<group>"; };
-		6E97D2892023CD5E00DD8368 /* StatisticsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
+		6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountOptionsViewController.swift; sourceTree = "<group>"; };
 		6E97D28A2023CD5F00DD8368 /* AccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountViewController.swift; sourceTree = "<group>"; };
 		6E97D28B2023CD5F00DD8368 /* LookupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupViewController.swift; sourceTree = "<group>"; };
 		6E97D28C2023CD6000DD8368 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -256,7 +256,7 @@
 				6ECD61F4203E755800E6068F /* MapRefreshButton.swift */,
 				6E71ED3E202621FE00EC17B9 /* MapViewController.swift */,
 				6E97D28F2023CD6100DD8368 /* SignInViewController.swift */,
-				6E97D2892023CD5E00DD8368 /* StatisticsViewController.swift */,
+				6E97D2892023CD5E00DD8368 /* AccountOptionsViewController.swift */,
 				6E97D28C2023CD6000DD8368 /* ViewController.swift */,
 			);
 			path = Controllers;
@@ -561,7 +561,7 @@
 				6EE12FD12024C71400509452 /* MainModel.swift in Sources */,
 				6E97D2932023CD6100DD8368 /* LookupViewController.swift in Sources */,
 				6E97D2952023CD6100DD8368 /* AttractionsTableViewCell.swift in Sources */,
-				6E97D2912023CD6100DD8368 /* StatisticsViewController.swift in Sources */,
+				6E97D2912023CD6100DD8368 /* AccountOptionsViewController.swift in Sources */,
 				6E71ED3D2026213F00EC17B9 /* MapModelObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BlipsClient.xcodeproj/project.pbxproj
+++ b/BlipsClient.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		6EA3A44720407987004E5B2B /* QueryOptionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */; };
 		6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */; };
 		6EA4065420265FED009069F4 /* LookupModelObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4065320265FED009069F4 /* LookupModelObserver.swift */; };
+		6EA84DBB2040DF05008C40A6 /* AttractionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA84DBA2040DF05008C40A6 /* AttractionHistory.swift */; };
+		6EA84DBD2040DF2E008C40A6 /* AutoQueryOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA84DBC2040DF2E008C40A6 /* AutoQueryOptions.swift */; };
 		6EAD4E831FBB8748003C2E30 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */; };
 		6ECD61F3203E6A8D00E6068F /* refresh.png in Resources */ = {isa = PBXBuildFile; fileRef = 6ECD61F2203E6A8C00E6068F /* refresh.png */; };
 		6ECD61F5203E755800E6068F /* MapRefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ECD61F4203E755800E6068F /* MapRefreshButton.swift */; };
@@ -122,6 +124,8 @@
 		6EA3A44620407987004E5B2B /* QueryOptionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsTableViewController.swift; sourceTree = "<group>"; };
 		6EA3A44A204091E9004E5B2B /* QueryOptionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOptionsObserver.swift; sourceTree = "<group>"; };
 		6EA4065320265FED009069F4 /* LookupModelObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LookupModelObserver.swift; sourceTree = "<group>"; };
+		6EA84DBA2040DF05008C40A6 /* AttractionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttractionHistory.swift; sourceTree = "<group>"; };
+		6EA84DBC2040DF2E008C40A6 /* AutoQueryOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoQueryOptions.swift; sourceTree = "<group>"; };
 		6EAD4E821FBB8748003C2E30 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		6ECD61F2203E6A8C00E6068F /* refresh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = refresh.png; sourceTree = "<group>"; };
 		6ECD61F4203E755800E6068F /* MapRefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapRefreshButton.swift; sourceTree = "<group>"; };
@@ -286,6 +290,8 @@
 		6E97D29A2023CDA100DD8368 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				6EA84DBA2040DF05008C40A6 /* AttractionHistory.swift */,
+				6EA84DBC2040DF2E008C40A6 /* AutoQueryOptions.swift */,
 				6E97D27C2023CD5500DD8368 /* Blip.swift */,
 				6E97D27D2023CD5500DD8368 /* BlipRequest.swift */,
 				6E97D27B2023CD5400DD8368 /* CustomLookup.swift */,
@@ -537,6 +543,7 @@
 				6E97D2782023CD4C00DD8368 /* UserAccountObserver.swift in Sources */,
 				6E97D2902023CD6100DD8368 /* AttributesTableViewController.swift in Sources */,
 				6ECE5E5B2030B35C00886884 /* BlipObserver.swift in Sources */,
+				6EA84DBD2040DF2E008C40A6 /* AutoQueryOptions.swift in Sources */,
 				6E18824E202CEF5000061C67 /* AnywhereUIAlertController.swift in Sources */,
 				6EA3A44B204091E9004E5B2B /* QueryOptionsObserver.swift in Sources */,
 				6E97D2792023CD4C00DD8368 /* ServerInterface.swift in Sources */,
@@ -549,6 +556,7 @@
 				6EDE4DE6202E971500E80AF7 /* BlipDetailViewController.swift in Sources */,
 				6E0EEE8A2037299700F38EE1 /* MapAccessoryView.swift in Sources */,
 				6ECE91942027B5EB009CAC91 /* BlipMarkerView.swift in Sources */,
+				6EA84DBB2040DF05008C40A6 /* AttractionHistory.swift in Sources */,
 				6E00C50D2037771300026E31 /* BlipTableToggleButton.swift in Sources */,
 				6ECE5E5F2031275800886884 /* BlipTableViewCell.swift in Sources */,
 				6E71ED3F202621FE00EC17B9 /* MapViewController.swift in Sources */,

--- a/BlipsClient/AppDelegate.swift
+++ b/BlipsClient/AppDelegate.swift
@@ -20,11 +20,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate, Lookup
 
     func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
         if (error == nil) {
-            // 120 for withDimension matches the width of the UIImageView used for the picture
-            // Try to set this as a constant, or maybe pull the value from IB
             // On login, set user ID as 0, and give an empty dictionary for atttraction history
             // These values will be retrieved from the server after the User object is created
-            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false)
+            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false, autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0)
             
             mainVC.relayUserLogin(account: account)
         } else {

--- a/BlipsClient/AppDelegate.swift
+++ b/BlipsClient/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate, Lookup
         if (error == nil) {
             // On login, set user ID as 0, and give an empty dictionary for atttraction history
             // These values will be retrieved from the server after the User object is created
-            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false, autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0)
+            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false, autoQueryOptions: AutoQueryOptions(autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0))
             
             mainVC.relayUserLogin(account: account)
         } else {

--- a/BlipsClient/AppDelegate.swift
+++ b/BlipsClient/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate, Lookup
         if (error == nil) {
             // On login, set user ID as 0, and give an empty dictionary for atttraction history
             // These values will be retrieved from the server after the User object is created
-            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false, autoQueryOptions: AutoQueryOptions(autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0))
+            let account = User(firstName: user.profile.givenName, lastName: user.profile.familyName, imageURL: user.profile.imageURL(withDimension: 240), email: user.profile.email, userID: 0, attractionHistory: [:], guest: false, autoQueryOptions: AutoQueryOptions(autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0), savedBlips: [Blip]())
             
             mainVC.relayUserLogin(account: account)
         } else {

--- a/BlipsClient/AppDelegate.swift
+++ b/BlipsClient/AppDelegate.swift
@@ -57,6 +57,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, GIDSignInDelegate, Lookup
         if (keySet == false) {
             keySet = true
             GMSPlacesClient.provideAPIKey(key)
+            mainVC.relayAPIKeyProvided()
         }
     }
 

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -925,12 +925,12 @@
         <scene sceneID="aiU-Qe-RMt">
             <objects>
                 <tableViewController id="8ly-By-pu2" customClass="QueryOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qkV-4C-R9o">
+                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qkV-4C-R9o">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
-                            <tableViewSection footerTitle="Globally enable or disable automatic querying when the app is opened." id="Aei-cD-EHi">
+                            <tableViewSection footerTitle="Globally enable or disable automatic querying when the app is opened." id="Aei-cD-EHi" userLabel="Automatic Queries Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iV4-WE-Plr">
                                         <rect key="frame" x="0.0" y="35" width="414" height="44"/>
@@ -960,7 +960,7 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR">
+                            <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR" userLabel="Attraction Types Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pOJ-jI-8qj">
                                         <rect key="frame" x="0.0" y="143" width="414" height="44"/>
@@ -993,10 +993,10 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection id="FxO-bs-D8A">
+                            <tableViewSection headerTitle="Lookup Attributes" id="FxO-bs-D8A">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zK4-ho-EMg">
-                                        <rect key="frame" x="0.0" y="251" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zK4-ho-EMg" userLabel="Open Now Cell">
+                                        <rect key="frame" x="0.0" y="271" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zK4-ho-EMg" id="QEc-dB-kFf">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
@@ -1018,6 +1018,107 @@
                                                 <constraint firstItem="skH-PJ-2PF" firstAttribute="centerY" secondItem="QEc-dB-kFf" secondAttribute="centerY" id="PNK-Hp-wbT"/>
                                                 <constraint firstItem="XaE-VE-n4r" firstAttribute="trailing" secondItem="QEc-dB-kFf" secondAttribute="trailingMargin" id="PSL-vR-E1H"/>
                                                 <constraint firstItem="XaE-VE-n4r" firstAttribute="leading" secondItem="skH-PJ-2PF" secondAttribute="trailing" id="lmo-QF-4hv"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pS4-Bl-SGD" userLabel="Price Cell">
+                                        <rect key="frame" x="0.0" y="315" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pS4-Bl-SGD" id="G0y-u1-tDe">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iyA-DF-fhG">
+                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
+                                                    <segments>
+                                                        <segment title="-"/>
+                                                        <segment title="$"/>
+                                                        <segment title="$$"/>
+                                                        <segment title="$$$"/>
+                                                    </segments>
+                                                </segmentedControl>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyR-tM-3u1">
+                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="iyA-DF-fhG" secondAttribute="trailing" id="06q-x1-DU2"/>
+                                                <constraint firstItem="iyA-DF-fhG" firstAttribute="centerY" secondItem="G0y-u1-tDe" secondAttribute="centerY" id="4er-1f-0Ux"/>
+                                                <constraint firstItem="iyA-DF-fhG" firstAttribute="leading" secondItem="G0y-u1-tDe" secondAttribute="centerX" id="Fe2-XG-fv8"/>
+                                                <constraint firstItem="wyR-tM-3u1" firstAttribute="leading" secondItem="G0y-u1-tDe" secondAttribute="leadingMargin" id="IlT-VN-5Hx"/>
+                                                <constraint firstItem="wyR-tM-3u1" firstAttribute="centerY" secondItem="G0y-u1-tDe" secondAttribute="centerY" id="gCe-YW-m6t"/>
+                                                <constraint firstItem="iyA-DF-fhG" firstAttribute="leading" secondItem="wyR-tM-3u1" secondAttribute="trailing" id="hAG-dc-hWz"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RKt-xU-taJ" userLabel="Rating Cell">
+                                        <rect key="frame" x="0.0" y="359" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RKt-xU-taJ" id="rsH-Mf-yCw">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-9C-O1Q">
+                                                    <rect key="frame" x="8" y="11" width="398" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
+                                                    <rect key="frame" x="298" y="11" width="108" height="21"/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="n8Z-bK-fzS" secondAttribute="height" multiplier="36:7" id="aUk-tT-GW4"/>
+                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="rating">
+                                                            <real key="value" value="0.0"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="filledColor">
+                                                            <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="totalStars">
+                                                            <integer key="value" value="5"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="starSize">
+                                                            <real key="value" value="21"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="emptyBorderColor">
+                                                            <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="filledBorderColor">
+                                                            <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="fillMode">
+                                                            <integer key="value" value="1"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="textMargin">
+                                                            <real key="value" value="0.0"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="emptyBorderWidth">
+                                                            <real key="value" value="1"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="filledBorderWidth">
+                                                            <real key="value" value="0.0"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="starMargin">
+                                                            <real key="value" value="0.0"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="textSize">
+                                                            <real key="value" value="0.0"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="n8Z-bK-fzS" firstAttribute="centerY" secondItem="rsH-Mf-yCw" secondAttribute="centerY" id="3uI-Y3-eAc"/>
+                                                <constraint firstItem="ATZ-9C-O1Q" firstAttribute="centerY" secondItem="rsH-Mf-yCw" secondAttribute="centerY" id="D9X-FS-ku7"/>
+                                                <constraint firstItem="ATZ-9C-O1Q" firstAttribute="trailing" secondItem="n8Z-bK-fzS" secondAttribute="trailing" id="TMO-CX-feT"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="n8Z-bK-fzS" secondAttribute="trailing" id="c3I-QB-oBl"/>
+                                                <constraint firstItem="ATZ-9C-O1Q" firstAttribute="leading" secondItem="rsH-Mf-yCw" secondAttribute="leadingMargin" id="rdy-cR-Sza"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -160,7 +160,7 @@
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JDg-lZ-PwS" userLabel="StatisticsView">
                                 <rect key="frame" x="0.0" y="316" width="320" height="252"/>
                                 <connections>
-                                    <segue destination="eMk-h0-xi3" kind="embed" id="TVO-r3-Fuf"/>
+                                    <segue destination="Wx2-Kv-5fu" kind="embed" id="U7G-N2-Wcy"/>
                                 </connections>
                             </containerView>
                         </subviews>
@@ -369,7 +369,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="196" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -774,7 +774,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Saa-Y1-bo3">
-                                <rect key="frame" x="104" y="0.0" width="112" height="112.5"/>
+                                <rect key="frame" x="104" y="8" width="112" height="112.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Saa-Y1-bo3" secondAttribute="height" multiplier="1:1" id="fK5-3C-dFJ"/>
                                 </constraints>
@@ -787,30 +787,30 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vl0-1b-AJY">
-                                <rect key="frame" x="160" y="120.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="160" y="128.5" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gbM-6J-IQQ">
-                                <rect key="frame" x="160" y="123.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="160" y="131.5" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Vl0-1b-AJY" firstAttribute="centerX" secondItem="IbW-zT-ORA" secondAttribute="centerX" id="2zl-Zw-0uq"/>
                             <constraint firstItem="gbM-6J-IQQ" firstAttribute="firstBaseline" secondItem="Vl0-1b-AJY" secondAttribute="baseline" constant="24" symbolType="layoutAnchor" id="J4D-f5-oPe"/>
-                            <constraint firstItem="Saa-Y1-bo3" firstAttribute="top" secondItem="IbW-zT-ORA" secondAttribute="top" id="MNx-vD-6xZ"/>
+                            <constraint firstItem="Saa-Y1-bo3" firstAttribute="top" secondItem="IbW-zT-ORA" secondAttribute="top" constant="8" id="MNx-vD-6xZ"/>
                             <constraint firstItem="Saa-Y1-bo3" firstAttribute="width" secondItem="IbW-zT-ORA" secondAttribute="width" multiplier="0.35" id="OYk-La-St3"/>
                             <constraint firstItem="gbM-6J-IQQ" firstAttribute="centerX" secondItem="IbW-zT-ORA" secondAttribute="centerX" id="XLr-bP-f77"/>
                             <constraint firstItem="CXE-wR-2CI" firstAttribute="bottom" secondItem="IbW-zT-ORA" secondAttribute="bottom" id="e0Y-tH-8rF"/>
                             <constraint firstItem="CXE-wR-2CI" firstAttribute="width" secondItem="IbW-zT-ORA" secondAttribute="width" multiplier="0.9" id="fog-0j-CBR"/>
                             <constraint firstItem="CXE-wR-2CI" firstAttribute="centerX" secondItem="IbW-zT-ORA" secondAttribute="centerX" id="gST-Fu-TIj"/>
                             <constraint firstItem="Saa-Y1-bo3" firstAttribute="centerX" secondItem="IbW-zT-ORA" secondAttribute="centerX" id="pcP-ir-c7a"/>
-                            <constraint firstItem="Vl0-1b-AJY" firstAttribute="firstBaseline" secondItem="Saa-Y1-bo3" secondAttribute="baseline" constant="24.333333333333332" symbolType="layoutAnchor" id="pu2-qW-nOU"/>
+                            <constraint firstItem="Vl0-1b-AJY" firstAttribute="firstBaseline" secondItem="Saa-Y1-bo3" secondAttribute="baseline" constant="24.5" symbolType="layoutAnchor" id="pu2-qW-nOU"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="IbW-zT-ORA"/>
                     </view>
@@ -825,20 +825,67 @@
             </objects>
             <point key="canvasLocation" x="3453.5999999999999" y="-355.04926108374383"/>
         </scene>
-        <!--Account Options View Controller-->
-        <scene sceneID="Ytu-PL-1Yz">
+        <!--Account Options Table View Controller-->
+        <scene sceneID="11R-UF-eWp">
             <objects>
-                <viewController id="eMk-h0-xi3" customClass="AccountOptionsViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="JxN-Pc-sko">
+                <tableViewController id="Wx2-Kv-5fu" customClass="AccountOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="P0p-HU-3Iq">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <viewLayoutGuide key="safeArea" id="rc9-fp-h4a"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="VRd-lK-EJK" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections>
+                            <tableViewSection id="y32-xE-0fZ">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="E8t-Xu-DM5">
+                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E8t-Xu-DM5" id="q6R-y4-5ow">
+                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Saved Blips" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlk-fK-3IB">
+                                                    <rect key="frame" x="16" y="11" width="95" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="i0I-Qu-Ssa">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8jk-Hh-o6c">
+                                        <rect key="frame" x="0.0" y="115" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8jk-Hh-o6c" id="QB6-Dc-rg6">
+                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Autoquery Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVs-sk-ucn">
+                                                    <rect key="frame" x="16" y="11" width="144" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Wx2-Kv-5fu" id="GRv-5d-IJs"/>
+                            <outlet property="delegate" destination="Wx2-Kv-5fu" id="EEW-g0-u5B"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Mnq-r2-SA4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3451" y="52"/>
+            <point key="canvasLocation" x="3451.875" y="-7.394366197183099"/>
         </scene>
     </scenes>
     <resources>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oy0-1Q-Q7N">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,21 +21,21 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ciU-To-jH3">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="wGA-DM-R7L" customClass="MapViewController" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="672"/>
                                 <viewLayoutGuide key="safeArea" id="R5Y-L0-f0R"/>
                             </mapView>
                             <containerView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hD-vo-HIh" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="5tQ-Uo-2c5" kind="embed" id="BZp-u9-tPQ"/>
                                 </connections>
                             </containerView>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fc6-hV-NtL" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="291" width="320" height="25"/>
+                                <rect key="frame" x="0.0" y="366.33333333333331" width="414" height="33.666666666666686"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <connections>
@@ -43,18 +43,18 @@
                                 </connections>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mrc-IX-dqe" customClass="BlipTableToggleButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="273.5" y="244.5" width="38.5" height="38.5"/>
+                                <rect key="frame" x="356.33333333333331" y="308.66666666666669" width="49.666666666666686" height="49.666666666666686"/>
                                 <state key="normal" title="Button" image="down-arrow.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="toggleTableView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="csS-ot-ckZ"/>
                                 </connections>
                             </button>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gkT-VB-ph0" userLabel="ToggleLeadingPlaceholder">
-                                <rect key="frame" x="46.5" y="252" width="227.5" height="39"/>
+                                <rect key="frame" x="57.666666666666657" y="316" width="299" height="50.333333333333314"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3oR-4r-zlC" customClass="MapRefreshButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="8" y="244.5" width="38.5" height="38.5"/>
+                                <rect key="frame" x="7.9999999999999964" y="308.66666666666669" width="49.666666666666657" height="49.666666666666686"/>
                                 <state key="normal" image="refresh.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="refreshMap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xys-2H-tnN"/>
@@ -132,7 +132,7 @@
             <objects>
                 <navigationController id="5Wk-dX-UOh" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="81V-M5-lrj">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -148,17 +148,17 @@
             <objects>
                 <viewController id="7a5-gA-atf" customClass="AccountViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1Yi-Sn-0aq">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Bh-uQ-4At" userLabel="AccountInfo">
-                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
                                 <connections>
                                     <segue destination="Z6Z-pR-1yI" kind="embed" id="WKm-3f-ceL"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JDg-lZ-PwS" userLabel="StatisticsView">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="Wx2-Kv-5fu" kind="embed" id="U7G-N2-Wcy"/>
                                 </connections>
@@ -203,17 +203,17 @@
             <objects>
                 <viewController id="IZE-pE-ALY" customClass="LookupViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="q1V-oR-29e">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ON-hG-IgY" userLabel="AttractionList">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="pz4-Od-fzr" kind="embed" id="mKe-O3-YZW"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fq4-zh-LqM" userLabel="LookupAttributes">
-                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
                                 <connections>
                                     <segue destination="uuS-1d-xbI" kind="embed" id="1Xu-IZ-08y"/>
                                 </connections>
@@ -258,17 +258,17 @@
             <objects>
                 <tableViewController id="uuS-1d-xbI" customClass="AttributesTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="bgm-gd-Hzr">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Lookup Attributes" id="fO9-6w-P5a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="dXN-tq-bqL">
-                                        <rect key="frame" x="0.0" y="55.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dXN-tq-bqL" id="9vY-dX-XZl">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2Z-jR-LaE">
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pd5-66-anX">
-                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="345" y="6.6666666666666679" width="51" height="31.000000000000004"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="uuS-1d-xbI" eventType="valueChanged" id="XuE-IH-r47"/>
                                                     </connections>
@@ -292,20 +292,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="AJ6-1O-qqZ">
-                                        <rect key="frame" x="0.0" y="99.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.333333333333343" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AJ6-1O-qqZ" id="jxl-MY-QLO">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search Radius" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MCN-RS-Bhp">
-                                                    <rect key="frame" x="16" y="11" width="109.5" height="21"/>
+                                                    <rect key="frame" x="20.000000000000007" y="11" width="109.66666666666669" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
-                                                    <rect key="frame" x="125.5" y="13.5" width="178.5" height="17"/>
+                                                    <rect key="frame" x="129.66666666666666" y="13.666666666666664" width="264.33333333333337" height="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -321,14 +321,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="c1D-h5-9fV">
-                                        <rect key="frame" x="0.0" y="143.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c1D-h5-9fV" id="6dW-aK-eIK">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9LK-OA-iy3">
-                                                    <rect key="frame" x="160" y="8" width="144" height="29"/>
+                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -340,7 +340,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyJ-g3-ygk">
-                                                    <rect key="frame" x="16" y="11" width="144" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -357,20 +357,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="OhX-Cn-OF6">
-                                        <rect key="frame" x="0.0" y="187.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="187.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OhX-Cn-OF6" id="vKk-kU-yzJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UI9-hF-Auk">
-                                                    <rect key="frame" x="16" y="11" width="288" height="21"/>
+                                                    <rect key="frame" x="20" y="11" width="374" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="196" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="286" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="CmA-cX-D04" secondAttribute="height" multiplier="36:7" id="P1j-V5-Kku"/>
@@ -450,19 +450,19 @@
             <objects>
                 <tableViewController id="pz4-Od-fzr" customClass="AttractionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="hNg-15-96H">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AttractionsTableViewCell" id="i3I-Sn-scl" customClass="AttractionsTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i3I-Sn-scl" id="gYi-Ih-npV">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ST9-x9-DIS">
-                                            <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.666666666666664"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -497,7 +497,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="oy0-1Q-Q7N" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gwM-bX-uJM">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -514,23 +514,23 @@
             <objects>
                 <viewController storyboardIdentifier="blipDetailView" id="wgI-J3-o53" customClass="BlipDetailViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dqb-Pb-sB0">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lu8-9P-Mmv">
-                                <rect key="frame" x="8" y="24" width="312" height="21"/>
+                                <rect key="frame" x="8" y="24" width="406" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWx-Gu-PZA">
-                                <rect key="frame" x="8" y="45" width="312" height="19.5"/>
+                                <rect key="frame" x="8" y="45" width="406" height="19.666666666666671"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
-                                <rect key="frame" x="8" y="70" width="312" height="21"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
+                                <rect key="frame" x="8" y="70" width="406" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="filledColor">
@@ -572,27 +572,27 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
-                                <rect key="frame" x="8" y="93.5" width="308" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
+                                <rect key="frame" x="8" y="93.666666666666671" width="402" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
                                     <action selector="gotoMaps:" destination="wgI-J3-o53" eventType="touchUpInside" id="aiS-Ea-09l"/>
                                 </connections>
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q2O-aF-V9k">
-                                <rect key="frame" x="0.0" y="294" width="320" height="274"/>
+                                <rect key="frame" x="0.0" y="378" width="414" height="358"/>
                                 <connections>
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
-                                <rect key="frame" x="8" y="94.5" width="312" height="0.0"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
+                                <rect key="frame" x="8" y="94.666666666666671" width="406" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
-                                <rect key="frame" x="0.0" y="116.5" width="320" height="175.5"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
+                                <rect key="frame" x="0.0" y="116.66666666666666" width="414" height="259.33333333333337"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -659,11 +659,11 @@
             <objects>
                 <viewController storyboardIdentifier="blipPhotoVC" id="neZ-Yg-ToW" customClass="BlipPhotoViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Vzq-42-Gwx">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Rt-EX-cWX">
-                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
+                                <rect key="frame" x="0.0" y="20" width="414" height="716"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -688,31 +688,31 @@
             <objects>
                 <tableViewController id="5tQ-Uo-2c5" customClass="BlipTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ub1-lq-2fj">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlipTableViewCell" id="oga-9n-hdN" customClass="BlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oga-9n-hdN" id="Xsi-rr-zCX">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jbt-bo-Kdt">
-                                            <rect key="frame" x="16" y="6" width="33" height="33"/>
+                                            <rect key="frame" x="20" y="6" width="33" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="jbt-bo-Kdt" secondAttribute="height" multiplier="1:1" id="CNe-tE-trC"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KE7-ag-xbg" userLabel="Type">
-                                            <rect key="frame" x="275.5" y="15.5" width="28.5" height="13.5"/>
+                                            <rect key="frame" x="365.66666666666669" y="15.666666666666664" width="28.333333333333314" height="13.333333333333336"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LZS-ao-vm7">
-                                            <rect key="frame" x="57" y="13.5" width="218.5" height="17"/>
+                                            <rect key="frame" x="61" y="13.666666666666664" width="304.66666666666669" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -753,7 +753,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="QM7-nQ-Cp7" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5kW-Vh-moY">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -770,30 +770,30 @@
             <objects>
                 <viewController id="Z6Z-pR-1yI" customClass="SignInViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="7ux-UX-PVb">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Saa-Y1-bo3">
-                                <rect key="frame" x="104" y="8" width="112" height="112.5"/>
+                                <rect key="frame" x="134.66666666666669" y="8" width="144.66666666666669" height="145.33333333333334"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Saa-Y1-bo3" secondAttribute="height" multiplier="1:1" id="fK5-3C-dFJ"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CXE-wR-2CI" customClass="GIDSignInButton">
-                                <rect key="frame" x="16" y="208" width="288" height="44"/>
+                                <rect key="frame" x="20.666666666666657" y="292" width="372.66666666666674" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="INQ-Nf-Njz"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vl0-1b-AJY">
-                                <rect key="frame" x="160" y="128.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="207" y="161.33333333333334" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gbM-6J-IQQ">
-                                <rect key="frame" x="160" y="131.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="207" y="164.33333333333334" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -829,18 +829,18 @@
         <scene sceneID="11R-UF-eWp">
             <objects>
                 <tableViewController id="Wx2-Kv-5fu" customClass="AccountOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="P0p-HU-3Iq">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="P0p-HU-3Iq">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection id="y32-xE-0fZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="E8t-Xu-DM5">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E8t-Xu-DM5" id="q6R-y4-5ow">
-                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Saved Blips" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlk-fK-3IB">
@@ -852,16 +852,19 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="PWW-WQ-sxz" kind="show" id="ChC-W5-rpi"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection id="i0I-Qu-Ssa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8jk-Hh-o6c">
-                                        <rect key="frame" x="0.0" y="115" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="115" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8jk-Hh-o6c" id="QB6-Dc-rg6">
-                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Autoquery Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVs-sk-ucn">
@@ -873,6 +876,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="8ly-By-pu2" kind="show" id="aIU-i1-HtW"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -886,6 +892,147 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Mnq-r2-SA4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3451.875" y="-7.394366197183099"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="Xoo-WE-6TF">
+            <objects>
+                <tableViewController id="PWW-WQ-sxz" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ud2-Fh-1oT">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PHx-9e-1oN">
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PHx-9e-1oN" id="eAD-2H-jis">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="PWW-WQ-sxz" id="2c5-OB-mYU"/>
+                            <outlet property="delegate" destination="PWW-WQ-sxz" id="baM-XL-MWG"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Pux-d9-dEd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4719" y="-261"/>
+        </scene>
+        <!--Query Options Table View Controller-->
+        <scene sceneID="aiU-Qe-RMt">
+            <objects>
+                <tableViewController id="8ly-By-pu2" customClass="QueryOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qkV-4C-R9o">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <sections>
+                            <tableViewSection footerTitle="Globally enable or disable automatic querying when the app is opened." id="Aei-cD-EHi">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iV4-WE-Plr">
+                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iV4-WE-Plr" id="4Zn-fg-BEC">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatic Queries" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIe-0a-yp8">
+                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTP-Ol-lK8">
+                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="hIe-0a-yp8" firstAttribute="centerY" secondItem="4Zn-fg-BEC" secondAttribute="centerY" id="1pn-YF-lPw"/>
+                                                <constraint firstItem="hIe-0a-yp8" firstAttribute="leading" secondItem="4Zn-fg-BEC" secondAttribute="leadingMargin" id="YN5-Lm-9YY"/>
+                                                <constraint firstItem="gTP-Ol-lK8" firstAttribute="leading" secondItem="hIe-0a-yp8" secondAttribute="trailing" id="pQs-td-ubB"/>
+                                                <constraint firstItem="gTP-Ol-lK8" firstAttribute="centerY" secondItem="4Zn-fg-BEC" secondAttribute="centerY" id="vNz-op-fki"/>
+                                                <constraint firstItem="gTP-Ol-lK8" firstAttribute="trailing" secondItem="4Zn-fg-BEC" secondAttribute="trailingMargin" id="xeC-fs-EAv"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pOJ-jI-8qj">
+                                        <rect key="frame" x="0.0" y="143" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pOJ-jI-8qj" id="Wz1-Ix-Ts9">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Types" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pmv-C2-Mck">
+                                                    <rect key="frame" x="20.000000000000007" y="11" width="125.66666666666669" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="3" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eab-nZ-CQg">
+                                                    <rect key="frame" x="137.66666666666666" y="11" width="256.33333333333337" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="pmv-C2-Mck" firstAttribute="leading" secondItem="Wz1-Ix-Ts9" secondAttribute="leadingMargin" id="3k7-Nm-SsF"/>
+                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="trailing" secondItem="Wz1-Ix-Ts9" secondAttribute="trailingMargin" id="5aO-n6-aWD"/>
+                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="leading" secondItem="pmv-C2-Mck" secondAttribute="trailingMargin" id="EHE-Ua-uz5"/>
+                                                <constraint firstItem="pmv-C2-Mck" firstAttribute="centerY" secondItem="Wz1-Ix-Ts9" secondAttribute="centerY" id="ics-PC-TXW"/>
+                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="centerY" secondItem="Wz1-Ix-Ts9" secondAttribute="centerY" id="qPd-ab-CPh"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="FxO-bs-D8A">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zK4-ho-EMg">
+                                        <rect key="frame" x="0.0" y="251" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zK4-ho-EMg" id="QEc-dB-kFf">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="skH-PJ-2PF">
+                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XaE-VE-n4r">
+                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="XaE-VE-n4r" firstAttribute="centerY" secondItem="QEc-dB-kFf" secondAttribute="centerY" id="0Ey-Gd-LP3"/>
+                                                <constraint firstItem="skH-PJ-2PF" firstAttribute="leading" secondItem="QEc-dB-kFf" secondAttribute="leadingMargin" id="O5U-zD-t81"/>
+                                                <constraint firstItem="skH-PJ-2PF" firstAttribute="centerY" secondItem="QEc-dB-kFf" secondAttribute="centerY" id="PNK-Hp-wbT"/>
+                                                <constraint firstItem="XaE-VE-n4r" firstAttribute="trailing" secondItem="QEc-dB-kFf" secondAttribute="trailingMargin" id="PSL-vR-E1H"/>
+                                                <constraint firstItem="XaE-VE-n4r" firstAttribute="leading" secondItem="skH-PJ-2PF" secondAttribute="trailing" id="lmo-QF-4hv"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="8ly-By-pu2" id="fBS-jK-Jkk"/>
+                            <outlet property="delegate" destination="8ly-By-pu2" id="jfF-Sw-Ypo"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2BU-gb-Wov" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4718.840579710145" y="167.93478260869566"/>
         </scene>
     </scenes>
     <resources>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -264,7 +264,7 @@
                         <sections>
                             <tableViewSection headerTitle="Lookup Attributes" id="fO9-6w-P5a">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="dXN-tq-bqL">
+                                    <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="dXN-tq-bqL" userLabel="Open Now Cell">
                                         <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dXN-tq-bqL" id="9vY-dX-XZl">
@@ -291,7 +291,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="AJ6-1O-qqZ">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="AJ6-1O-qqZ" userLabel="Radius Cell">
                                         <rect key="frame" x="0.0" y="99.333333333333343" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AJ6-1O-qqZ" id="jxl-MY-QLO">
@@ -320,7 +320,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="c1D-h5-9fV">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="c1D-h5-9fV" userLabel="Price Cell">
                                         <rect key="frame" x="0.0" y="143.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c1D-h5-9fV" id="6dW-aK-eIK">
@@ -356,7 +356,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="OhX-Cn-OF6">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="OhX-Cn-OF6" userLabel="Rating Cell">
                                         <rect key="frame" x="0.0" y="187.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OhX-Cn-OF6" id="vKk-kU-yzJ">
@@ -433,11 +433,7 @@
                         </connections>
                     </tableView>
                     <connections>
-                        <outlet property="openNowCell" destination="dXN-tq-bqL" id="t8o-kE-ezF"/>
-                        <outlet property="priceCell" destination="c1D-h5-9fV" id="KOZ-ZG-ut9"/>
-                        <outlet property="radiusCell" destination="AJ6-1O-qqZ" id="cXs-YQ-yBN"/>
                         <outlet property="radiusTextField" destination="5TU-NL-fvB" id="Mgm-KM-gqO"/>
-                        <outlet property="ratingCell" destination="OhX-Cn-OF6" id="0re-TJ-0Sf"/>
                         <outlet property="starView" destination="CmA-cX-D04" id="zT0-TI-xfJ"/>
                     </connections>
                 </tableViewController>
@@ -1130,6 +1126,9 @@
                             <outlet property="delegate" destination="8ly-By-pu2" id="jfF-Sw-Ypo"/>
                         </connections>
                     </tableView>
+                    <connections>
+                        <outlet property="attractionTypesField" destination="Eab-nZ-CQg" id="FDL-kU-lMa"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2BU-gb-Wov" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -369,7 +369,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="196" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -529,7 +529,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
                                 <rect key="frame" x="8" y="70" width="312" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
@@ -572,7 +572,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
                                 <rect key="frame" x="8" y="93.5" width="308" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
@@ -585,13 +585,13 @@
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
                                 <rect key="frame" x="8" y="94.5" width="312" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
                                 <rect key="frame" x="0.0" y="116.5" width="320" height="175.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -825,10 +825,10 @@
             </objects>
             <point key="canvasLocation" x="3453.5999999999999" y="-355.04926108374383"/>
         </scene>
-        <!--Statistics View Controller-->
+        <!--Account Options View Controller-->
         <scene sceneID="Ytu-PL-1Yz">
             <objects>
-                <viewController id="eMk-h0-xi3" customClass="StatisticsViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="eMk-h0-xi3" customClass="AccountOptionsViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="JxN-Pc-sko">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -369,7 +369,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="286" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -525,7 +525,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
+                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
                                 <rect key="frame" x="8" y="70" width="406" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
@@ -568,7 +568,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
+                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
                                 <rect key="frame" x="8" y="93.666666666666671" width="402" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
@@ -581,13 +581,13 @@
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
                                 <rect key="frame" x="8" y="94.666666666666671" width="406" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
                                 <rect key="frame" x="0.0" y="116.66666666666666" width="414" height="259.33333333333337"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -1073,7 +1073,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="298" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -1138,6 +1138,9 @@
                     </tableView>
                     <connections>
                         <outlet property="attractionTypesToSelect" destination="RdU-Ft-L9b" id="Nxo-Mg-O3p"/>
+                        <outlet property="autoQueryEnabledSwitch" destination="gTP-Ol-lK8" id="kUB-Fo-xUd"/>
+                        <outlet property="openNowSwitch" destination="XaE-VE-n4r" id="WCQ-IX-kLB"/>
+                        <outlet property="priceRangeControl" destination="iyA-DF-fhG" id="JdT-S4-Dyt"/>
                         <outlet property="starView" destination="n8Z-bK-fzS" id="RbV-He-4AW"/>
                     </connections>
                 </tableViewController>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pd5-66-anX">
-                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="uuS-1d-xbI" eventType="valueChanged" id="XuE-IH-r47"/>
                                                     </connections>
@@ -305,7 +305,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
-                                                    <rect key="frame" x="125.5" y="12.5" width="233.5" height="19"/>
+                                                    <rect key="frame" x="125.5" y="12.5" width="178.5" height="19"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -328,7 +328,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9LK-OA-iy3">
-                                                    <rect key="frame" x="187.5" y="8" width="171.5" height="29"/>
+                                                    <rect key="frame" x="160" y="8" width="144" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -340,7 +340,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyJ-g3-ygk">
-                                                    <rect key="frame" x="16" y="11" width="171.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="11" width="144" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -364,13 +364,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UI9-hF-Auk">
-                                                    <rect key="frame" x="16" y="11" width="343" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="288" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="251" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="196" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="CmA-cX-D04" secondAttribute="height" multiplier="36:7" id="P1j-V5-Kku"/>
@@ -458,7 +458,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ST9-x9-DIS">
-                                            <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -514,13 +514,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lu8-9P-Mmv">
-                                <rect key="frame" x="8" y="24" width="240" height="21"/>
+                                <rect key="frame" x="8" y="24" width="312" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWx-Gu-PZA">
-                                <rect key="frame" x="8" y="45" width="312" height="19.5"/>
+                                <rect key="frame" x="8" y="45" width="120" height="19.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -594,8 +594,8 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3ZD-ad-mJP">
-                                <rect key="frame" x="248" y="19" width="68" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3ZD-ad-mJP">
+                                <rect key="frame" x="128" y="40" width="188" height="30"/>
                                 <state key="normal" title="Save"/>
                                 <connections>
                                     <action selector="saveBlip:" destination="wgI-J3-o53" eventType="touchUpInside" id="x2I-jj-MWA"/>
@@ -605,14 +605,14 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="bottom" secondItem="RdX-5b-Xth" secondAttribute="bottom" id="3nv-ze-73H"/>
+                            <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="50b-5u-kkG"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="height" secondItem="RdX-5b-Xth" secondAttribute="height" multiplier="0.5" id="Aa5-Fw-enV"/>
                             <constraint firstItem="zWx-Gu-PZA" firstAttribute="top" secondItem="lu8-9P-Mmv" secondAttribute="bottom" id="E8u-G9-nhb"/>
-                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="trailing" secondItem="3ZD-ad-mJP" secondAttribute="leading" id="FVl-hO-HUe"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="firstBaseline" secondItem="Ogb-ZI-2Wr" secondAttribute="baseline" constant="20" id="LZU-f2-SAg"/>
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="trailing" secondItem="b9K-b3-gQS" secondAttribute="trailing" constant="-4" id="LpR-FO-7FO"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="centerX" secondItem="RdX-5b-Xth" secondAttribute="centerX" id="Ml3-Rg-oBC"/>
-                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="width" secondItem="RdX-5b-Xth" secondAttribute="width" multiplier="0.75" id="Owy-cO-etE"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="leading" secondItem="Ogb-ZI-2Wr" secondAttribute="leading" id="PVN-p3-vwl"/>
+                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="PWW-vk-t53"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="bottom" secondItem="RdX-5b-Xth" secondAttribute="centerY" constant="-2" id="Qfe-ez-u6z"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="width" secondItem="RdX-5b-Xth" secondAttribute="width" id="R1o-Cd-S4r"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="firstBaseline" secondItem="tR9-f6-3IM" secondAttribute="baseline" constant="3" id="RDA-XS-M6C"/>
@@ -620,14 +620,14 @@
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="leading" secondItem="b9K-b3-gQS" secondAttribute="leading" id="VkL-f2-rGY"/>
                             <constraint firstItem="3ZD-ad-mJP" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" constant="-4" id="W7p-k9-hF7"/>
                             <constraint firstItem="lu8-9P-Mmv" firstAttribute="top" secondItem="RdX-5b-Xth" secondAttribute="top" constant="4" id="Ysd-IN-5mh"/>
-                            <constraint firstItem="3ZD-ad-mJP" firstAttribute="centerY" secondItem="lu8-9P-Mmv" secondAttribute="centerY" id="ZEM-Dr-MMb"/>
+                            <constraint firstItem="3ZD-ad-mJP" firstAttribute="centerY" secondItem="zWx-Gu-PZA" secondAttribute="centerY" id="ZEM-Dr-MMb"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="centerX" secondItem="RdX-5b-Xth" secondAttribute="centerX" id="a67-rG-jTD"/>
                             <constraint firstItem="lu8-9P-Mmv" firstAttribute="leading" secondItem="RdX-5b-Xth" secondAttribute="leading" constant="8" id="c98-gv-aEj"/>
-                            <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="trailing" secondItem="zWx-Gu-PZA" secondAttribute="trailing" id="fZH-p6-Pke"/>
+                            <constraint firstItem="3ZD-ad-mJP" firstAttribute="leading" secondItem="zWx-Gu-PZA" secondAttribute="trailing" id="i80-fE-6iv"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="leading" secondItem="RdX-5b-Xth" secondAttribute="leading" id="kz8-ig-KoX"/>
                             <constraint firstItem="zWx-Gu-PZA" firstAttribute="leading" secondItem="lu8-9P-Mmv" secondAttribute="leading" id="l6T-7C-xX5"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="trailing" secondItem="Ogb-ZI-2Wr" secondAttribute="trailing" id="pCn-hY-bJt"/>
-                            <constraint firstItem="zWx-Gu-PZA" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="sTp-rO-ZsA"/>
+                            <constraint firstItem="zWx-Gu-PZA" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" multiplier="0.4" id="sTp-rO-ZsA"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="t58-53-cJb"/>
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="firstBaseline" secondItem="b9K-b3-gQS" secondAttribute="baseline" constant="24" id="vif-Oj-34p"/>
                             <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="firstBaseline" secondItem="zWx-Gu-PZA" secondAttribute="baseline" constant="10" id="zsc-H2-dYI"/>
@@ -947,13 +947,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatic Queries" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIe-0a-yp8">
-                                                    <rect key="frame" x="16" y="11" width="294" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="239" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTP-Ol-lK8">
-                                                    <rect key="frame" x="310" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="autoQueryEnabledChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="Zrx-nU-KCc"/>
                                                     </connections>
@@ -986,7 +986,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RdU-Ft-L9b">
-                                                    <rect key="frame" x="142" y="13.5" width="217" height="17"/>
+                                                    <rect key="frame" x="142" y="13.5" width="162" height="17"/>
                                                     <color key="tintColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -1014,13 +1014,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="skH-PJ-2PF">
-                                                    <rect key="frame" x="16" y="11" width="294" height="21"/>
+                                                    <rect key="frame" x="8" y="11" width="255" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XaE-VE-n4r">
-                                                    <rect key="frame" x="310" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="263" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="3bg-On-kcr"/>
                                                     </connections>
@@ -1043,7 +1043,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iyA-DF-fhG">
-                                                    <rect key="frame" x="187.5" y="8" width="171.5" height="29"/>
+                                                    <rect key="frame" x="160" y="8" width="152" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -1055,7 +1055,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyR-tM-3u1">
-                                                    <rect key="frame" x="16" y="11" width="171.5" height="20.5"/>
+                                                    <rect key="frame" x="8" y="11" width="152" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1079,13 +1079,13 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-9C-O1Q">
-                                                    <rect key="frame" x="8" y="11" width="359" height="21"/>
+                                                    <rect key="frame" x="8" y="11" width="304" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="259" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="204" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="n8Z-bK-fzS" secondAttribute="height" multiplier="36:7" id="aUk-tT-GW4"/>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -369,7 +369,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="286" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -525,7 +525,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
                                 <rect key="frame" x="8" y="70" width="406" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
@@ -568,7 +568,7 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
                                 <rect key="frame" x="8" y="93.666666666666671" width="402" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
@@ -581,13 +581,13 @@
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
                                 <rect key="frame" x="8" y="94.666666666666671" width="406" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
                                 <rect key="frame" x="0.0" y="116.66666666666666" width="414" height="259.33333333333337"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
@@ -1073,7 +1073,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
                                                     <rect key="frame" x="298" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
@@ -1137,6 +1137,7 @@
                         </connections>
                     </tableView>
                     <connections>
+                        <outlet property="attractionTypeToSelectLabel" destination="pmv-C2-Mck" id="gk1-xg-yz2"/>
                         <outlet property="attractionTypesToSelect" destination="RdU-Ft-L9b" id="Nxo-Mg-O3p"/>
                         <outlet property="autoQueryEnabledSwitch" destination="gTP-Ol-lK8" id="kUB-Fo-xUd"/>
                         <outlet property="openNowSwitch" destination="XaE-VE-n4r" id="WCQ-IX-kLB"/>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -900,22 +900,58 @@
             </objects>
             <point key="canvasLocation" x="3451.875" y="-7.394366197183099"/>
         </scene>
-        <!--Table View Controller-->
+        <!--Saved Blip Table View Controller-->
         <scene sceneID="Xoo-WE-6TF">
             <objects>
-                <tableViewController id="PWW-WQ-sxz" sceneMemberID="viewController">
+                <tableViewController id="PWW-WQ-sxz" customClass="SavedBlipTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ud2-Fh-1oT">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PHx-9e-1oN">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlipTableViewCell" id="3po-gQ-oQh" customClass="BlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PHx-9e-1oN" id="eAD-2H-jis">
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3po-gQ-oQh" id="mqm-hC-nSc">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GcU-CI-fcH">
+                                            <rect key="frame" x="16" y="6" width="33" height="33"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" secondItem="GcU-CI-fcH" secondAttribute="height" multiplier="1:1" id="oDa-HM-NpD"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNX-qH-iZC" userLabel="Type">
+                                            <rect key="frame" x="275.5" y="15.5" width="28.5" height="13.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDV-xJ-ks7">
+                                            <rect key="frame" x="57" y="13.5" width="218.5" height="17"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="kNX-qH-iZC" firstAttribute="leading" secondItem="eDV-xJ-ks7" secondAttribute="trailing" id="0uS-Vg-ebS"/>
+                                        <constraint firstItem="GcU-CI-fcH" firstAttribute="leading" secondItem="mqm-hC-nSc" secondAttribute="leadingMargin" id="5BS-BI-1NO"/>
+                                        <constraint firstItem="GcU-CI-fcH" firstAttribute="top" secondItem="mqm-hC-nSc" secondAttribute="topMargin" constant="-5" id="DXe-sM-htb"/>
+                                        <constraint firstItem="eDV-xJ-ks7" firstAttribute="leading" secondItem="GcU-CI-fcH" secondAttribute="trailing" constant="8" id="FOT-dC-V2v"/>
+                                        <constraint firstItem="GcU-CI-fcH" firstAttribute="bottom" secondItem="mqm-hC-nSc" secondAttribute="bottomMargin" constant="6" id="TaM-al-HjF"/>
+                                        <constraint firstItem="kNX-qH-iZC" firstAttribute="centerY" secondItem="mqm-hC-nSc" secondAttribute="centerY" id="Zst-cD-BnO"/>
+                                        <constraint firstItem="eDV-xJ-ks7" firstAttribute="centerY" secondItem="mqm-hC-nSc" secondAttribute="centerY" id="s20-qo-gcH"/>
+                                        <constraint firstItem="kNX-qH-iZC" firstAttribute="trailing" secondItem="mqm-hC-nSc" secondAttribute="trailingMargin" id="zXc-47-2DC"/>
+                                    </constraints>
                                 </tableViewCellContentView>
+                                <gestureRecognizers/>
+                                <connections>
+                                    <outlet property="blipName" destination="eDV-xJ-ks7" id="qt3-7f-gws"/>
+                                    <outlet property="blipType" destination="kNX-qH-iZC" id="GIP-S1-Gce"/>
+                                    <outlet property="typeImage" destination="GcU-CI-fcH" id="3tm-yQ-YMX"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oy0-1Q-Q7N">
-    <device id="retina5_5" orientation="portrait">
+    <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,21 +21,21 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ciU-To-jH3">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="wGA-DM-R7L" customClass="MapViewController" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="64" width="414" height="672"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                                 <viewLayoutGuide key="safeArea" id="R5Y-L0-f0R"/>
                             </mapView>
                             <containerView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hD-vo-HIh" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
+                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
                                 <connections>
                                     <segue destination="5tQ-Uo-2c5" kind="embed" id="BZp-u9-tPQ"/>
                                 </connections>
                             </containerView>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fc6-hV-NtL" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="366.33333333333331" width="414" height="33.666666666666686"/>
+                                <rect key="frame" x="0.0" y="291" width="320" height="25"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <connections>
@@ -43,18 +43,18 @@
                                 </connections>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mrc-IX-dqe" customClass="BlipTableToggleButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="356.33333333333331" y="308.66666666666669" width="49.666666666666686" height="49.666666666666686"/>
+                                <rect key="frame" x="273.5" y="244" width="38.5" height="39"/>
                                 <state key="normal" title="Button" image="down-arrow.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="toggleTableView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="csS-ot-ckZ"/>
                                 </connections>
                             </button>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gkT-VB-ph0" userLabel="ToggleLeadingPlaceholder">
-                                <rect key="frame" x="57.666666666666657" y="316" width="299" height="50.333333333333314"/>
+                                <rect key="frame" x="46.5" y="252" width="227.5" height="39"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3oR-4r-zlC" customClass="MapRefreshButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="7.9999999999999964" y="308.66666666666669" width="49.666666666666657" height="49.666666666666686"/>
+                                <rect key="frame" x="8" y="244" width="38.5" height="39"/>
                                 <state key="normal" image="refresh.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="refreshMap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xys-2H-tnN"/>
@@ -132,7 +132,7 @@
             <objects>
                 <navigationController id="5Wk-dX-UOh" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="81V-M5-lrj">
-                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -148,17 +148,17 @@
             <objects>
                 <viewController id="7a5-gA-atf" customClass="AccountViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1Yi-Sn-0aq">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Bh-uQ-4At" userLabel="AccountInfo">
-                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
                                 <connections>
                                     <segue destination="Z6Z-pR-1yI" kind="embed" id="WKm-3f-ceL"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JDg-lZ-PwS" userLabel="StatisticsView">
-                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
+                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
                                 <connections>
                                     <segue destination="Wx2-Kv-5fu" kind="embed" id="U7G-N2-Wcy"/>
                                 </connections>
@@ -203,17 +203,17 @@
             <objects>
                 <viewController id="IZE-pE-ALY" customClass="LookupViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="q1V-oR-29e">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ON-hG-IgY" userLabel="AttractionList">
-                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
+                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
                                 <connections>
                                     <segue destination="pz4-Od-fzr" kind="embed" id="mKe-O3-YZW"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fq4-zh-LqM" userLabel="LookupAttributes">
-                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
                                 <connections>
                                     <segue destination="uuS-1d-xbI" kind="embed" id="1Xu-IZ-08y"/>
                                 </connections>
@@ -258,17 +258,17 @@
             <objects>
                 <tableViewController id="uuS-1d-xbI" customClass="AttributesTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="bgm-gd-Hzr">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Lookup Attributes" id="fO9-6w-P5a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="dXN-tq-bqL" userLabel="Open Now Cell">
-                                        <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dXN-tq-bqL" id="9vY-dX-XZl">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2Z-jR-LaE">
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pd5-66-anX">
-                                                    <rect key="frame" x="345" y="6.6666666666666679" width="51" height="31.000000000000004"/>
+                                                    <rect key="frame" x="310" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="uuS-1d-xbI" eventType="valueChanged" id="XuE-IH-r47"/>
                                                     </connections>
@@ -292,20 +292,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="AJ6-1O-qqZ" userLabel="Radius Cell">
-                                        <rect key="frame" x="0.0" y="99.333333333333343" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AJ6-1O-qqZ" id="jxl-MY-QLO">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search Radius" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MCN-RS-Bhp">
-                                                    <rect key="frame" x="20.000000000000007" y="11" width="109.66666666666669" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="109.5" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
-                                                    <rect key="frame" x="129.66666666666666" y="12.666666666666664" width="264.33333333333337" height="19"/>
+                                                    <rect key="frame" x="125.5" y="12.5" width="233.5" height="19"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -321,14 +321,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="c1D-h5-9fV" userLabel="Price Cell">
-                                        <rect key="frame" x="0.0" y="143.33333333333334" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c1D-h5-9fV" id="6dW-aK-eIK">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9LK-OA-iy3">
-                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
+                                                    <rect key="frame" x="187.5" y="8" width="171.5" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -340,7 +340,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyJ-g3-ygk">
-                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
+                                                    <rect key="frame" x="16" y="11" width="171.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -357,20 +357,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="OhX-Cn-OF6" userLabel="Rating Cell">
-                                        <rect key="frame" x="0.0" y="187.33333333333334" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="187.5" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OhX-Cn-OF6" id="vKk-kU-yzJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UI9-hF-Auk">
-                                                    <rect key="frame" x="20" y="11" width="374" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="343" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="286" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="251" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="CmA-cX-D04" secondAttribute="height" multiplier="36:7" id="P1j-V5-Kku"/>
@@ -446,19 +446,19 @@
             <objects>
                 <tableViewController id="pz4-Od-fzr" customClass="AttractionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="hNg-15-96H">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AttractionsTableViewCell" id="i3I-Sn-scl" customClass="AttractionsTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i3I-Sn-scl" id="gYi-Ih-npV">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ST9-x9-DIS">
-                                            <rect key="frame" x="20" y="0.0" width="374" height="43.666666666666664"/>
+                                            <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -493,7 +493,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="oy0-1Q-Q7N" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gwM-bX-uJM">
-                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -510,23 +510,23 @@
             <objects>
                 <viewController storyboardIdentifier="blipDetailView" id="wgI-J3-o53" customClass="BlipDetailViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dqb-Pb-sB0">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lu8-9P-Mmv">
-                                <rect key="frame" x="8" y="24" width="406" height="21"/>
+                                <rect key="frame" x="8" y="24" width="240" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWx-Gu-PZA">
-                                <rect key="frame" x="8" y="45" width="406" height="19.666666666666671"/>
+                                <rect key="frame" x="8" y="45" width="312" height="19.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
-                                <rect key="frame" x="8" y="70" width="406" height="21"/>
+                                <rect key="frame" x="8" y="70" width="312" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="filledColor">
@@ -569,55 +569,65 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
-                                <rect key="frame" x="8" y="93.666666666666671" width="402" height="30"/>
+                                <rect key="frame" x="8" y="93.5" width="308" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
                                     <action selector="gotoMaps:" destination="wgI-J3-o53" eventType="touchUpInside" id="aiS-Ea-09l"/>
                                 </connections>
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q2O-aF-V9k">
-                                <rect key="frame" x="0.0" y="378" width="414" height="358"/>
+                                <rect key="frame" x="0.0" y="294" width="320" height="274"/>
                                 <connections>
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
-                                <rect key="frame" x="8" y="94.666666666666671" width="406" height="0.0"/>
+                                <rect key="frame" x="8" y="94.5" width="312" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
-                                <rect key="frame" x="0.0" y="116.66666666666666" width="414" height="259.33333333333337"/>
+                                <rect key="frame" x="0.0" y="116.5" width="320" height="175.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3ZD-ad-mJP">
+                                <rect key="frame" x="248" y="19" width="68" height="30"/>
+                                <state key="normal" title="Save"/>
+                                <connections>
+                                    <action selector="saveBlip:" destination="wgI-J3-o53" eventType="touchUpInside" id="x2I-jj-MWA"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="bottom" secondItem="RdX-5b-Xth" secondAttribute="bottom" id="3nv-ze-73H"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="height" secondItem="RdX-5b-Xth" secondAttribute="height" multiplier="0.5" id="Aa5-Fw-enV"/>
                             <constraint firstItem="zWx-Gu-PZA" firstAttribute="top" secondItem="lu8-9P-Mmv" secondAttribute="bottom" id="E8u-G9-nhb"/>
+                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="trailing" secondItem="3ZD-ad-mJP" secondAttribute="leading" id="FVl-hO-HUe"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="firstBaseline" secondItem="Ogb-ZI-2Wr" secondAttribute="baseline" constant="20" id="LZU-f2-SAg"/>
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="trailing" secondItem="b9K-b3-gQS" secondAttribute="trailing" constant="-4" id="LpR-FO-7FO"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="centerX" secondItem="RdX-5b-Xth" secondAttribute="centerX" id="Ml3-Rg-oBC"/>
+                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="width" secondItem="RdX-5b-Xth" secondAttribute="width" multiplier="0.75" id="Owy-cO-etE"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="leading" secondItem="Ogb-ZI-2Wr" secondAttribute="leading" id="PVN-p3-vwl"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="bottom" secondItem="RdX-5b-Xth" secondAttribute="centerY" constant="-2" id="Qfe-ez-u6z"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="width" secondItem="RdX-5b-Xth" secondAttribute="width" id="R1o-Cd-S4r"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="firstBaseline" secondItem="tR9-f6-3IM" secondAttribute="baseline" constant="3" id="RDA-XS-M6C"/>
                             <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="leading" secondItem="zWx-Gu-PZA" secondAttribute="leading" id="RLp-oy-YOG"/>
-                            <constraint firstItem="lu8-9P-Mmv" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="RNx-4b-uwz"/>
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="leading" secondItem="b9K-b3-gQS" secondAttribute="leading" id="VkL-f2-rGY"/>
+                            <constraint firstItem="3ZD-ad-mJP" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" constant="-4" id="W7p-k9-hF7"/>
                             <constraint firstItem="lu8-9P-Mmv" firstAttribute="top" secondItem="RdX-5b-Xth" secondAttribute="top" constant="4" id="Ysd-IN-5mh"/>
+                            <constraint firstItem="3ZD-ad-mJP" firstAttribute="centerY" secondItem="lu8-9P-Mmv" secondAttribute="centerY" id="ZEM-Dr-MMb"/>
                             <constraint firstItem="Q2O-aF-V9k" firstAttribute="centerX" secondItem="RdX-5b-Xth" secondAttribute="centerX" id="a67-rG-jTD"/>
                             <constraint firstItem="lu8-9P-Mmv" firstAttribute="leading" secondItem="RdX-5b-Xth" secondAttribute="leading" constant="8" id="c98-gv-aEj"/>
                             <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="trailing" secondItem="zWx-Gu-PZA" secondAttribute="trailing" id="fZH-p6-Pke"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="leading" secondItem="RdX-5b-Xth" secondAttribute="leading" id="kz8-ig-KoX"/>
                             <constraint firstItem="zWx-Gu-PZA" firstAttribute="leading" secondItem="lu8-9P-Mmv" secondAttribute="leading" id="l6T-7C-xX5"/>
-                            <constraint firstItem="zWx-Gu-PZA" firstAttribute="trailing" secondItem="lu8-9P-Mmv" secondAttribute="trailing" id="oAy-2o-eBi"/>
                             <constraint firstItem="b9K-b3-gQS" firstAttribute="trailing" secondItem="Ogb-ZI-2Wr" secondAttribute="trailing" id="pCn-hY-bJt"/>
+                            <constraint firstItem="zWx-Gu-PZA" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="sTp-rO-ZsA"/>
                             <constraint firstItem="sFj-gu-upS" firstAttribute="trailing" secondItem="RdX-5b-Xth" secondAttribute="trailing" id="t58-53-cJb"/>
                             <constraint firstItem="tR9-f6-3IM" firstAttribute="firstBaseline" secondItem="b9K-b3-gQS" secondAttribute="baseline" constant="24" id="vif-Oj-34p"/>
                             <constraint firstItem="Ogb-ZI-2Wr" firstAttribute="firstBaseline" secondItem="zWx-Gu-PZA" secondAttribute="baseline" constant="10" id="zsc-H2-dYI"/>
@@ -636,11 +646,12 @@
                         <outlet property="getDirectionsButton" destination="tR9-f6-3IM" id="2gG-VS-8WD"/>
                         <outlet property="photoViewContainer" destination="Q2O-aF-V9k" id="90T-Vm-jqX"/>
                         <outlet property="photoViewHeight" destination="Aa5-Fw-enV" id="BHw-Oh-L61"/>
+                        <outlet property="saveButton" destination="3ZD-ad-mJP" id="Rd4-co-Mvo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qhT-GZ-ZGr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-60" y="1505.9113300492611"/>
+            <point key="canvasLocation" x="-60.869565217391312" y="1505.7065217391305"/>
         </scene>
         <!--Page View Controller-->
         <scene sceneID="Lx3-Ss-rtO">
@@ -655,11 +666,11 @@
             <objects>
                 <viewController storyboardIdentifier="blipPhotoVC" id="neZ-Yg-ToW" customClass="BlipPhotoViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Vzq-42-Gwx">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Rt-EX-cWX">
-                                <rect key="frame" x="0.0" y="20" width="414" height="716"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -684,31 +695,31 @@
             <objects>
                 <tableViewController id="5tQ-Uo-2c5" customClass="BlipTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ub1-lq-2fj">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlipTableViewCell" id="oga-9n-hdN" customClass="BlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oga-9n-hdN" id="Xsi-rr-zCX">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jbt-bo-Kdt">
-                                            <rect key="frame" x="20" y="6" width="33" height="33"/>
+                                            <rect key="frame" x="16" y="6" width="33" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="jbt-bo-Kdt" secondAttribute="height" multiplier="1:1" id="CNe-tE-trC"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KE7-ag-xbg" userLabel="Type">
-                                            <rect key="frame" x="365.66666666666669" y="15.666666666666664" width="28.333333333333314" height="13.333333333333336"/>
+                                            <rect key="frame" x="275.5" y="15.5" width="28.5" height="13.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LZS-ao-vm7">
-                                            <rect key="frame" x="61" y="13.666666666666664" width="304.66666666666669" height="17"/>
+                                            <rect key="frame" x="57" y="13.5" width="218.5" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -749,7 +760,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="QM7-nQ-Cp7" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5kW-Vh-moY">
-                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -766,30 +777,30 @@
             <objects>
                 <viewController id="Z6Z-pR-1yI" customClass="SignInViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="7ux-UX-PVb">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Saa-Y1-bo3">
-                                <rect key="frame" x="134.66666666666669" y="8" width="144.66666666666669" height="145.33333333333334"/>
+                                <rect key="frame" x="104" y="8" width="112" height="112.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Saa-Y1-bo3" secondAttribute="height" multiplier="1:1" id="fK5-3C-dFJ"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CXE-wR-2CI" customClass="GIDSignInButton">
-                                <rect key="frame" x="20.666666666666657" y="292" width="372.66666666666674" height="44"/>
+                                <rect key="frame" x="16" y="208" width="288" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="INQ-Nf-Njz"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vl0-1b-AJY">
-                                <rect key="frame" x="207" y="161.33333333333334" width="0.0" height="0.0"/>
+                                <rect key="frame" x="160" y="128.5" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gbM-6J-IQQ">
-                                <rect key="frame" x="207" y="164.33333333333334" width="0.0" height="0.0"/>
+                                <rect key="frame" x="160" y="131.5" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -826,17 +837,17 @@
             <objects>
                 <tableViewController id="Wx2-Kv-5fu" customClass="AccountOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="P0p-HU-3Iq">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection id="y32-xE-0fZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="E8t-Xu-DM5">
-                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E8t-Xu-DM5" id="q6R-y4-5ow">
-                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Saved Blips" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlk-fK-3IB">
@@ -857,10 +868,10 @@
                             <tableViewSection id="i0I-Qu-Ssa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8jk-Hh-o6c">
-                                        <rect key="frame" x="0.0" y="115" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="115" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8jk-Hh-o6c" id="QB6-Dc-rg6">
-                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Autoquery Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVs-sk-ucn">
@@ -894,15 +905,15 @@
             <objects>
                 <tableViewController id="PWW-WQ-sxz" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ud2-Fh-1oT">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="PHx-9e-1oN">
-                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PHx-9e-1oN" id="eAD-2H-jis">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -922,27 +933,27 @@
             <objects>
                 <tableViewController id="8ly-By-pu2" customClass="QueryOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qkV-4C-R9o">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection footerTitle="Globally enable or disable automatic querying when the app is opened." id="Aei-cD-EHi" userLabel="Automatic Queries Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iV4-WE-Plr">
-                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iV4-WE-Plr" id="4Zn-fg-BEC">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatic Queries" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIe-0a-yp8">
-                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="294" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTP-Ol-lK8">
-                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="310" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="autoQueryEnabledChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="Zrx-nU-KCc"/>
                                                     </connections>
@@ -962,20 +973,20 @@
                             <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR" userLabel="Attraction Types Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pOJ-jI-8qj">
-                                        <rect key="frame" x="0.0" y="143" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="143" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pOJ-jI-8qj" id="Wz1-Ix-Ts9">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Types" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pmv-C2-Mck">
-                                                    <rect key="frame" x="20.000000000000007" y="11" width="125.66666666666669" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="126" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RdU-Ft-L9b">
-                                                    <rect key="frame" x="145.66666666666663" y="13.333333333333336" width="248.33333333333337" height="17"/>
+                                                    <rect key="frame" x="142" y="13.5" width="217" height="17"/>
                                                     <color key="tintColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -996,20 +1007,20 @@
                             <tableViewSection headerTitle="Lookup Attributes" id="FxO-bs-D8A">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zK4-ho-EMg" userLabel="Open Now Cell">
-                                        <rect key="frame" x="0.0" y="271" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="271" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zK4-ho-EMg" id="QEc-dB-kFf">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="skH-PJ-2PF">
-                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
+                                                    <rect key="frame" x="16" y="11" width="294" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XaE-VE-n4r">
-                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="310" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="3bg-On-kcr"/>
                                                     </connections>
@@ -1025,14 +1036,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pS4-Bl-SGD" userLabel="Price Cell">
-                                        <rect key="frame" x="0.0" y="315" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="315" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pS4-Bl-SGD" id="G0y-u1-tDe">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iyA-DF-fhG">
-                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
+                                                    <rect key="frame" x="187.5" y="8" width="171.5" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -1044,7 +1055,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyR-tM-3u1">
-                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
+                                                    <rect key="frame" x="16" y="11" width="171.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1061,20 +1072,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="RKt-xU-taJ" userLabel="Rating Cell">
-                                        <rect key="frame" x="0.0" y="359" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="359" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RKt-xU-taJ" id="rsH-Mf-yCw">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-9C-O1Q">
-                                                    <rect key="frame" x="8" y="11" width="398" height="21"/>
+                                                    <rect key="frame" x="8" y="11" width="359" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="298" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="259" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="n8Z-bK-fzS" secondAttribute="height" multiplier="36:7" id="aUk-tT-GW4"/>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oy0-1Q-Q7N">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -21,21 +21,21 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ciU-To-jH3">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="wGA-DM-R7L" customClass="MapViewController" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="64" width="320" height="504"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="672"/>
                                 <viewLayoutGuide key="safeArea" id="R5Y-L0-f0R"/>
                             </mapView>
                             <containerView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hD-vo-HIh" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="5tQ-Uo-2c5" kind="embed" id="BZp-u9-tPQ"/>
                                 </connections>
                             </containerView>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.65000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fc6-hV-NtL" customClass="MapAccessoryView" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="291" width="320" height="25"/>
+                                <rect key="frame" x="0.0" y="366.33333333333331" width="414" height="33.666666666666686"/>
                                 <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <connections>
@@ -43,18 +43,18 @@
                                 </connections>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="bottom" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Mrc-IX-dqe" customClass="BlipTableToggleButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="273.5" y="244" width="38.5" height="39"/>
+                                <rect key="frame" x="356.33333333333331" y="308" width="49.666666666666686" height="50.333333333333314"/>
                                 <state key="normal" title="Button" image="down-arrow.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="toggleTableView:" destination="BYZ-38-t0r" eventType="touchUpInside" id="csS-ot-ckZ"/>
                                 </connections>
                             </button>
                             <view hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gkT-VB-ph0" userLabel="ToggleLeadingPlaceholder">
-                                <rect key="frame" x="46.5" y="252" width="227.5" height="39"/>
+                                <rect key="frame" x="57.666666666666657" y="316" width="299" height="50.333333333333314"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <button hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.0" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3oR-4r-zlC" customClass="MapRefreshButton" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="8" y="244" width="38.5" height="39"/>
+                                <rect key="frame" x="7.9999999999999964" y="308" width="49.666666666666657" height="50.333333333333314"/>
                                 <state key="normal" image="refresh.png" backgroundImage="background.png"/>
                                 <connections>
                                     <action selector="refreshMap:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xys-2H-tnN"/>
@@ -132,7 +132,7 @@
             <objects>
                 <navigationController id="5Wk-dX-UOh" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="81V-M5-lrj">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -148,17 +148,17 @@
             <objects>
                 <viewController id="7a5-gA-atf" customClass="AccountViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1Yi-Sn-0aq">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Bh-uQ-4At" userLabel="AccountInfo">
-                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
                                 <connections>
                                     <segue destination="Z6Z-pR-1yI" kind="embed" id="WKm-3f-ceL"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JDg-lZ-PwS" userLabel="StatisticsView">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="Wx2-Kv-5fu" kind="embed" id="U7G-N2-Wcy"/>
                                 </connections>
@@ -203,17 +203,17 @@
             <objects>
                 <viewController id="IZE-pE-ALY" customClass="LookupViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="q1V-oR-29e">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2ON-hG-IgY" userLabel="AttractionList">
-                                <rect key="frame" x="0.0" y="316" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="400" width="414" height="336"/>
                                 <connections>
                                     <segue destination="pz4-Od-fzr" kind="embed" id="mKe-O3-YZW"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fq4-zh-LqM" userLabel="LookupAttributes">
-                                <rect key="frame" x="0.0" y="64" width="320" height="252"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="336"/>
                                 <connections>
                                     <segue destination="uuS-1d-xbI" kind="embed" id="1Xu-IZ-08y"/>
                                 </connections>
@@ -258,17 +258,17 @@
             <objects>
                 <tableViewController id="uuS-1d-xbI" customClass="AttributesTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="bgm-gd-Hzr">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Lookup Attributes" id="fO9-6w-P5a">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="dXN-tq-bqL" userLabel="Open Now Cell">
-                                        <rect key="frame" x="0.0" y="55.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.333333333333336" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dXN-tq-bqL" id="9vY-dX-XZl">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R2Z-jR-LaE">
@@ -279,7 +279,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pd5-66-anX">
-                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="345" y="6.6666666666666679" width="51" height="31.000000000000004"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="uuS-1d-xbI" eventType="valueChanged" id="XuE-IH-r47"/>
                                                     </connections>
@@ -292,20 +292,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="AJ6-1O-qqZ" userLabel="Radius Cell">
-                                        <rect key="frame" x="0.0" y="99.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.333333333333343" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AJ6-1O-qqZ" id="jxl-MY-QLO">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Search Radius" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MCN-RS-Bhp">
-                                                    <rect key="frame" x="16" y="11" width="109.5" height="21"/>
+                                                    <rect key="frame" x="20.000000000000007" y="11" width="109.66666666666669" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
-                                                    <rect key="frame" x="125.5" y="12.5" width="178.5" height="19"/>
+                                                    <rect key="frame" x="129.66666666666666" y="12.666666666666664" width="264.33333333333337" height="19"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -321,14 +321,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="c1D-h5-9fV" userLabel="Price Cell">
-                                        <rect key="frame" x="0.0" y="143.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c1D-h5-9fV" id="6dW-aK-eIK">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9LK-OA-iy3">
-                                                    <rect key="frame" x="160" y="8" width="144" height="29"/>
+                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -340,7 +340,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZyJ-g3-ygk">
-                                                    <rect key="frame" x="16" y="11" width="144" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -357,20 +357,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="OhX-Cn-OF6" userLabel="Rating Cell">
-                                        <rect key="frame" x="0.0" y="187.5" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="187.33333333333334" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OhX-Cn-OF6" id="vKk-kU-yzJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UI9-hF-Auk">
-                                                    <rect key="frame" x="16" y="11" width="288" height="21"/>
+                                                    <rect key="frame" x="20" y="11" width="374" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CmA-cX-D04" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="196" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="286" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="CmA-cX-D04" secondAttribute="height" multiplier="36:7" id="P1j-V5-Kku"/>
@@ -446,19 +446,19 @@
             <objects>
                 <tableViewController id="pz4-Od-fzr" customClass="AttractionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="hNg-15-96H">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AttractionsTableViewCell" id="i3I-Sn-scl" customClass="AttractionsTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="i3I-Sn-scl" id="gYi-Ih-npV">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ST9-x9-DIS">
-                                            <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.666666666666664"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -493,7 +493,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="oy0-1Q-Q7N" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="gwM-bX-uJM">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -510,23 +510,23 @@
             <objects>
                 <viewController storyboardIdentifier="blipDetailView" id="wgI-J3-o53" customClass="BlipDetailViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dqb-Pb-sB0">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lu8-9P-Mmv">
-                                <rect key="frame" x="8" y="24" width="312" height="21"/>
+                                <rect key="frame" x="8" y="24" width="406" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zWx-Gu-PZA">
-                                <rect key="frame" x="8" y="45" width="120" height="19.5"/>
+                                <rect key="frame" x="8" y="45" width="157.66666666666666" height="19.666666666666671"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ogb-ZI-2Wr" customClass="CosmosView" customModule="Cosmos">
-                                <rect key="frame" x="8" y="70" width="312" height="21"/>
+                                <rect key="frame" x="8" y="70" width="406" height="21"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="color" keyPath="filledColor">
@@ -569,33 +569,33 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tR9-f6-3IM">
-                                <rect key="frame" x="8" y="93.5" width="308" height="30"/>
+                                <rect key="frame" x="8" y="93.666666666666671" width="402" height="30"/>
                                 <state key="normal" title="Get Directions in Maps"/>
                                 <connections>
                                     <action selector="gotoMaps:" destination="wgI-J3-o53" eventType="touchUpInside" id="aiS-Ea-09l"/>
                                 </connections>
                             </button>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q2O-aF-V9k">
-                                <rect key="frame" x="0.0" y="294" width="320" height="274"/>
+                                <rect key="frame" x="0.0" y="378" width="414" height="358"/>
                                 <connections>
                                     <segue destination="PXF-er-3uX" kind="embed" id="eE8-Bh-L4i"/>
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9K-b3-gQS">
-                                <rect key="frame" x="8" y="94.5" width="312" height="0.0"/>
+                                <rect key="frame" x="8" y="94.666666666666671" width="406" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sFj-gu-upS">
-                                <rect key="frame" x="0.0" y="116.5" width="320" height="175.5"/>
+                                <rect key="frame" x="0.0" y="116.66666666666666" width="414" height="259.33333333333337"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3ZD-ad-mJP">
-                                <rect key="frame" x="128" y="40" width="188" height="30"/>
+                                <rect key="frame" x="165.66666666666663" y="40" width="244.33333333333337" height="30"/>
                                 <state key="normal" title="Save"/>
                                 <connections>
                                     <action selector="saveBlip:" destination="wgI-J3-o53" eventType="touchUpInside" id="x2I-jj-MWA"/>
@@ -666,11 +666,11 @@
             <objects>
                 <viewController storyboardIdentifier="blipPhotoVC" id="neZ-Yg-ToW" customClass="BlipPhotoViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Vzq-42-Gwx">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3Rt-EX-cWX">
-                                <rect key="frame" x="0.0" y="20" width="320" height="548"/>
+                                <rect key="frame" x="0.0" y="20" width="414" height="716"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -695,31 +695,31 @@
             <objects>
                 <tableViewController id="5tQ-Uo-2c5" customClass="BlipTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ub1-lq-2fj">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlipTableViewCell" id="oga-9n-hdN" customClass="BlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oga-9n-hdN" id="Xsi-rr-zCX">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jbt-bo-Kdt">
-                                            <rect key="frame" x="16" y="6" width="33" height="33"/>
+                                            <rect key="frame" x="20" y="6" width="33" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="jbt-bo-Kdt" secondAttribute="height" multiplier="1:1" id="CNe-tE-trC"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KE7-ag-xbg" userLabel="Type">
-                                            <rect key="frame" x="275.5" y="15.5" width="28.5" height="13.5"/>
+                                            <rect key="frame" x="365.66666666666669" y="15.666666666666664" width="28.333333333333314" height="13.333333333333336"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LZS-ao-vm7">
-                                            <rect key="frame" x="57" y="13.5" width="218.5" height="17"/>
+                                            <rect key="frame" x="61" y="13.666666666666664" width="304.66666666666669" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -760,7 +760,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="QM7-nQ-Cp7" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="5kW-Vh-moY">
-                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -777,30 +777,30 @@
             <objects>
                 <viewController id="Z6Z-pR-1yI" customClass="SignInViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="7ux-UX-PVb">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Saa-Y1-bo3">
-                                <rect key="frame" x="104" y="8" width="112" height="112.5"/>
+                                <rect key="frame" x="134.66666666666669" y="8" width="144.66666666666669" height="145.33333333333334"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Saa-Y1-bo3" secondAttribute="height" multiplier="1:1" id="fK5-3C-dFJ"/>
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CXE-wR-2CI" customClass="GIDSignInButton">
-                                <rect key="frame" x="16" y="208" width="288" height="44"/>
+                                <rect key="frame" x="20.666666666666657" y="292" width="372.66666666666674" height="44"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="44" id="INQ-Nf-Njz"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vl0-1b-AJY">
-                                <rect key="frame" x="160" y="128.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="207" y="161.33333333333334" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gbM-6J-IQQ">
-                                <rect key="frame" x="160" y="131.5" width="0.0" height="0.0"/>
+                                <rect key="frame" x="207" y="164.33333333333334" width="0.0" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -837,17 +837,17 @@
             <objects>
                 <tableViewController id="Wx2-Kv-5fu" customClass="AccountOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="P0p-HU-3Iq">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection id="y32-xE-0fZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="E8t-Xu-DM5">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="E8t-Xu-DM5" id="q6R-y4-5ow">
-                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Saved Blips" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlk-fK-3IB">
@@ -868,10 +868,10 @@
                             <tableViewSection id="i0I-Qu-Ssa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="8jk-Hh-o6c">
-                                        <rect key="frame" x="0.0" y="115" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="115" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8jk-Hh-o6c" id="QB6-Dc-rg6">
-                                            <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Autoquery Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVs-sk-ucn">
@@ -905,49 +905,59 @@
             <objects>
                 <tableViewController id="PWW-WQ-sxz" customClass="SavedBlipTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ud2-Fh-1oT">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlipTableViewCell" id="3po-gQ-oQh" customClass="BlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SavedBlipTableViewCell" id="3po-gQ-oQh" customClass="SavedBlipTableViewCell" customModule="BlipsClient" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3po-gQ-oQh" id="mqm-hC-nSc">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GcU-CI-fcH">
-                                            <rect key="frame" x="16" y="6" width="33" height="33"/>
+                                            <rect key="frame" x="20" y="6" width="33" height="33"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="GcU-CI-fcH" secondAttribute="height" multiplier="1:1" id="oDa-HM-NpD"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="751" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNX-qH-iZC" userLabel="Type">
-                                            <rect key="frame" x="275.5" y="15.5" width="28.5" height="13.5"/>
+                                            <rect key="frame" x="365.66666666666669" y="15.666666666666664" width="29.333333333333314" height="13.333333333333336"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eDV-xJ-ks7">
-                                            <rect key="frame" x="57" y="13.5" width="218.5" height="17"/>
+                                            <rect key="frame" x="61" y="6" width="296.33333333333331" height="17"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BvL-JU-Xy9">
+                                            <rect key="frame" x="61" y="22" width="296.33333333333331" height="16"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="kNX-qH-iZC" firstAttribute="leading" secondItem="eDV-xJ-ks7" secondAttribute="trailing" id="0uS-Vg-ebS"/>
+                                        <constraint firstItem="kNX-qH-iZC" firstAttribute="leading" secondItem="eDV-xJ-ks7" secondAttribute="trailing" constant="8" id="0uS-Vg-ebS"/>
+                                        <constraint firstItem="eDV-xJ-ks7" firstAttribute="top" secondItem="mqm-hC-nSc" secondAttribute="topMargin" constant="-5" id="3xa-mI-FJU"/>
                                         <constraint firstItem="GcU-CI-fcH" firstAttribute="leading" secondItem="mqm-hC-nSc" secondAttribute="leadingMargin" id="5BS-BI-1NO"/>
                                         <constraint firstItem="GcU-CI-fcH" firstAttribute="top" secondItem="mqm-hC-nSc" secondAttribute="topMargin" constant="-5" id="DXe-sM-htb"/>
                                         <constraint firstItem="eDV-xJ-ks7" firstAttribute="leading" secondItem="GcU-CI-fcH" secondAttribute="trailing" constant="8" id="FOT-dC-V2v"/>
+                                        <constraint firstItem="BvL-JU-Xy9" firstAttribute="leading" secondItem="GcU-CI-fcH" secondAttribute="trailing" constant="8" id="SEt-CT-vM9"/>
                                         <constraint firstItem="GcU-CI-fcH" firstAttribute="bottom" secondItem="mqm-hC-nSc" secondAttribute="bottomMargin" constant="6" id="TaM-al-HjF"/>
+                                        <constraint firstItem="BvL-JU-Xy9" firstAttribute="trailing" secondItem="eDV-xJ-ks7" secondAttribute="trailing" id="ZGB-KG-ofA"/>
                                         <constraint firstItem="kNX-qH-iZC" firstAttribute="centerY" secondItem="mqm-hC-nSc" secondAttribute="centerY" id="Zst-cD-BnO"/>
-                                        <constraint firstItem="eDV-xJ-ks7" firstAttribute="centerY" secondItem="mqm-hC-nSc" secondAttribute="centerY" id="s20-qo-gcH"/>
+                                        <constraint firstItem="BvL-JU-Xy9" firstAttribute="bottom" secondItem="mqm-hC-nSc" secondAttribute="bottomMargin" constant="5" id="e1s-Nw-Z3K"/>
                                         <constraint firstItem="kNX-qH-iZC" firstAttribute="trailing" secondItem="mqm-hC-nSc" secondAttribute="trailingMargin" id="zXc-47-2DC"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <gestureRecognizers/>
                                 <connections>
+                                    <outlet property="blipCityCountry" destination="BvL-JU-Xy9" id="cjP-Nd-cRM"/>
                                     <outlet property="blipName" destination="eDV-xJ-ks7" id="qt3-7f-gws"/>
                                     <outlet property="blipType" destination="kNX-qH-iZC" id="GIP-S1-Gce"/>
                                     <outlet property="typeImage" destination="GcU-CI-fcH" id="3tm-yQ-YMX"/>
@@ -966,34 +976,34 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pux-d9-dEd" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="dOS-oa-xsD" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="4719" y="-261"/>
+            <point key="canvasLocation" x="4718.840579710145" y="-261.68478260869568"/>
         </scene>
         <!--Query Options Table View Controller-->
         <scene sceneID="aiU-Qe-RMt">
             <objects>
                 <tableViewController id="8ly-By-pu2" customClass="QueryOptionsTableViewController" customModule="BlipsClient" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qkV-4C-R9o">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="252"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="336"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection footerTitle="Globally enable or disable automatic querying when the app is opened." id="Aei-cD-EHi" userLabel="Automatic Queries Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="iV4-WE-Plr">
-                                        <rect key="frame" x="0.0" y="35" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iV4-WE-Plr" id="4Zn-fg-BEC">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Automatic Queries" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hIe-0a-yp8">
-                                                    <rect key="frame" x="16" y="11" width="239" height="21"/>
+                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTP-Ol-lK8">
-                                                    <rect key="frame" x="255" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="autoQueryEnabledChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="Zrx-nU-KCc"/>
                                                     </connections>
@@ -1013,20 +1023,20 @@
                             <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR" userLabel="Attraction Types Section">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pOJ-jI-8qj">
-                                        <rect key="frame" x="0.0" y="143" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="143" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pOJ-jI-8qj" id="Wz1-Ix-Ts9">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attraction Types" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pmv-C2-Mck">
-                                                    <rect key="frame" x="16" y="11" width="126" height="21"/>
+                                                    <rect key="frame" x="20" y="11" width="126" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RdU-Ft-L9b">
-                                                    <rect key="frame" x="142" y="13.5" width="162" height="17"/>
+                                                    <rect key="frame" x="146" y="13.666666666666664" width="248" height="17"/>
                                                     <color key="tintColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -1047,20 +1057,20 @@
                             <tableViewSection headerTitle="Lookup Attributes" id="FxO-bs-D8A">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zK4-ho-EMg" userLabel="Open Now Cell">
-                                        <rect key="frame" x="0.0" y="271" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="271" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zK4-ho-EMg" id="QEc-dB-kFf">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open Now" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="skH-PJ-2PF">
-                                                    <rect key="frame" x="8" y="11" width="255" height="21"/>
+                                                    <rect key="frame" x="20" y="11" width="325" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XaE-VE-n4r">
-                                                    <rect key="frame" x="263" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="345" y="6" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="openNowChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="3bg-On-kcr"/>
                                                     </connections>
@@ -1076,14 +1086,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pS4-Bl-SGD" userLabel="Price Cell">
-                                        <rect key="frame" x="0.0" y="315" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="315" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pS4-Bl-SGD" id="G0y-u1-tDe">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="iyA-DF-fhG">
-                                                    <rect key="frame" x="160" y="8" width="152" height="29"/>
+                                                    <rect key="frame" x="207" y="8" width="187" height="29"/>
                                                     <segments>
                                                         <segment title="-"/>
                                                         <segment title="$"/>
@@ -1095,7 +1105,7 @@
                                                     </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyR-tM-3u1">
-                                                    <rect key="frame" x="8" y="11" width="152" height="20.5"/>
+                                                    <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1112,20 +1122,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="RKt-xU-taJ" userLabel="Rating Cell">
-                                        <rect key="frame" x="0.0" y="359" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="359" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RKt-xU-taJ" id="rsH-Mf-yCw">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Minimum Rating" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ATZ-9C-O1Q">
-                                                    <rect key="frame" x="8" y="11" width="304" height="21"/>
+                                                    <rect key="frame" x="8" y="11" width="398" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8Z-bK-fzS" customClass="CosmosView" customModule="Cosmos">
-                                                    <rect key="frame" x="204" y="11" width="108" height="21"/>
+                                                    <rect key="frame" x="298" y="11" width="108" height="21"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="n8Z-bK-fzS" secondAttribute="height" multiplier="36:7" id="aUk-tT-GW4"/>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -959,8 +959,12 @@
                             <outlet property="delegate" destination="PWW-WQ-sxz" id="baM-XL-MWG"/>
                         </connections>
                     </tableView>
+                    <connections>
+                        <segue destination="dOS-oa-xsD" kind="unwind" identifier="querySelectedBlips" unwindAction="unwindToBlipMapWithSender:" id="Cya-XW-tU1"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pux-d9-dEd" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="dOS-oa-xsD" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="4719" y="-261"/>
         </scene>

--- a/BlipsClient/Base.lproj/Main.storyboard
+++ b/BlipsClient/Base.lproj/Main.storyboard
@@ -304,8 +304,8 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
-                                                    <rect key="frame" x="129.66666666666666" y="13.666666666666664" width="264.33333333333337" height="17"/>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" clearsOnBeginEditing="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="5TU-NL-fvB">
+                                                    <rect key="frame" x="129.66666666666666" y="12.666666666666664" width="264.33333333333337" height="19"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -943,6 +943,9 @@
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gTP-Ol-lK8">
                                                     <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="autoQueryEnabledChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="Zrx-nU-KCc"/>
+                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -958,7 +961,7 @@
                             </tableViewSection>
                             <tableViewSection footerTitle="On automatic queries, how many of your top types should be selected." id="OrY-eE-mRR" userLabel="Attraction Types Section">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pOJ-jI-8qj">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pOJ-jI-8qj">
                                         <rect key="frame" x="0.0" y="143" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pOJ-jI-8qj" id="Wz1-Ix-Ts9">
@@ -971,19 +974,20 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="3" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eab-nZ-CQg">
-                                                    <rect key="frame" x="137.66666666666666" y="11" width="256.33333333333337" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="1" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RdU-Ft-L9b">
+                                                    <rect key="frame" x="145.66666666666663" y="13.333333333333336" width="248.33333333333337" height="17"/>
+                                                    <color key="tintColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="pmv-C2-Mck" firstAttribute="leading" secondItem="Wz1-Ix-Ts9" secondAttribute="leadingMargin" id="3k7-Nm-SsF"/>
-                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="trailing" secondItem="Wz1-Ix-Ts9" secondAttribute="trailingMargin" id="5aO-n6-aWD"/>
-                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="leading" secondItem="pmv-C2-Mck" secondAttribute="trailingMargin" id="EHE-Ua-uz5"/>
+                                                <constraint firstItem="RdU-Ft-L9b" firstAttribute="centerY" secondItem="Wz1-Ix-Ts9" secondAttribute="centerY" id="VD1-Nm-7OG"/>
+                                                <constraint firstItem="RdU-Ft-L9b" firstAttribute="trailing" secondItem="Wz1-Ix-Ts9" secondAttribute="trailingMargin" id="gR6-s9-vwK"/>
+                                                <constraint firstItem="RdU-Ft-L9b" firstAttribute="leading" secondItem="pmv-C2-Mck" secondAttribute="trailing" id="hLt-BX-w2u"/>
                                                 <constraint firstItem="pmv-C2-Mck" firstAttribute="centerY" secondItem="Wz1-Ix-Ts9" secondAttribute="centerY" id="ics-PC-TXW"/>
-                                                <constraint firstItem="Eab-nZ-CQg" firstAttribute="centerY" secondItem="Wz1-Ix-Ts9" secondAttribute="centerY" id="qPd-ab-CPh"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -1006,6 +1010,9 @@
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XaE-VE-n4r">
                                                     <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="openNowChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="3bg-On-kcr"/>
+                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -1017,7 +1024,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pS4-Bl-SGD" userLabel="Price Cell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="pS4-Bl-SGD" userLabel="Price Cell">
                                         <rect key="frame" x="0.0" y="315" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pS4-Bl-SGD" id="G0y-u1-tDe">
@@ -1032,6 +1039,9 @@
                                                         <segment title="$$"/>
                                                         <segment title="$$$"/>
                                                     </segments>
+                                                    <connections>
+                                                        <action selector="priceRangeChanged:" destination="8ly-By-pu2" eventType="valueChanged" id="Cwz-vo-8YF"/>
+                                                    </connections>
                                                 </segmentedControl>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Price" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyR-tM-3u1">
                                                     <rect key="frame" x="20" y="11.000000000000002" width="187" height="20.666666666666671"/>
@@ -1050,7 +1060,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RKt-xU-taJ" userLabel="Rating Cell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="RKt-xU-taJ" userLabel="Rating Cell">
                                         <rect key="frame" x="0.0" y="359" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="bottomRight" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RKt-xU-taJ" id="rsH-Mf-yCw">
@@ -1127,7 +1137,8 @@
                         </connections>
                     </tableView>
                     <connections>
-                        <outlet property="attractionTypesField" destination="Eab-nZ-CQg" id="FDL-kU-lMa"/>
+                        <outlet property="attractionTypesToSelect" destination="RdU-Ft-L9b" id="Nxo-Mg-O3p"/>
+                        <outlet property="starView" destination="n8Z-bK-fzS" id="RbV-He-4AW"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2BU-gb-Wov" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -28,7 +28,7 @@ class AccountOptionsTableViewController: UITableViewController, UserAccountObser
         self.account = nil
     }
     
-    func guestReplaced() {
+    func guestReplaced(guestQueried: Bool) {
         self.account = nil
     }
 

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class AccountOptionsTableViewController: UITableViewController, UserAccountObserver {
     var account: User!
-    
+
     // MARK: - Table view data source
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 2
@@ -37,11 +37,7 @@ class AccountOptionsTableViewController: UITableViewController, UserAccountObser
         if let queryOptionsVC = segue.destination as? QueryOptionsTableViewController {
             queryOptionsVC.addQueryOptionsObserver(observer: account)
             queryOptionsVC.attractionHistoryCount = account.getAttractionHistoryCount()
-            queryOptionsVC.openNow = account.autoQueryOpenNow
-            queryOptionsVC.autoQueryEnabled = account.autoQueryEnabled
-            queryOptionsVC.typeGrabLength = account.autoQueryTypeGrabLength
-            queryOptionsVC.rating = account.autoQueryRating
-            queryOptionsVC.priceRange = account.autoQueryPriceRange
+            queryOptionsVC.queryOptions = account.autoQueryOptions
         }
     }
 }

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -41,6 +41,7 @@ class AccountOptionsTableViewController: UITableViewController, UserAccountObser
         }
         
         if let savedBlipsVC = segue.destination as? SavedBlipTableViewController {
+            savedBlipsVC.addObserver(observer: account)
             savedBlipsVC.savedBlips = account.savedBlips
         }
     }

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -8,9 +8,10 @@
 
 import UIKit
 
-class AccountOptionsTableViewController: UITableViewController {
+class AccountOptionsTableViewController: UITableViewController, UserAccountObserver {
+    var account: User!
+    
     // MARK: - Table view data source
-
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }
@@ -18,12 +19,23 @@ class AccountOptionsTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1
     }
+    
+    func userLoggedIn(account: User) {
+        self.account = account
+    }
+    
+    func userLoggedOut() {
+        self.account = nil
+    }
+    
+    func guestReplaced() {
+        self.account = nil
+    }
 
     // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
+        if let queryOptionsVC = segue.destination as? QueryOptionsTableViewController {
+            queryOptionsVC.attractionHistoryCount = account.getAttractionHistoryCount()
+        }
     }
 }

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -35,7 +35,13 @@ class AccountOptionsTableViewController: UITableViewController, UserAccountObser
     // MARK: - Navigation
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let queryOptionsVC = segue.destination as? QueryOptionsTableViewController {
+            queryOptionsVC.addQueryOptionsObserver(observer: account)
             queryOptionsVC.attractionHistoryCount = account.getAttractionHistoryCount()
+            queryOptionsVC.openNow = account.autoQueryOpenNow
+            queryOptionsVC.autoQueryEnabled = account.autoQueryEnabled
+            queryOptionsVC.typeGrabLength = account.autoQueryTypeGrabLength
+            queryOptionsVC.rating = account.autoQueryRating
+            queryOptionsVC.priceRange = account.autoQueryPriceRange
         }
     }
 }

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -1,22 +1,24 @@
 //
-//  AccountOptionsViewController.swift
+//  AccountOptionsTableViewController.swift
 //  BlipsClient
 //
-//  Created by Cyrus Sadeghi on 2018-01-27.
+//  Created by Cyrus Sadeghi on 2018-02-22.
 //  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
 //
 
 import UIKit
 
-class AccountOptionsViewController: UIViewController {
+class AccountOptionsTableViewController: UITableViewController {
+    // MARK: - Table view data source
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
     }
 
-    /*
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation
@@ -24,6 +26,4 @@ class AccountOptionsViewController: UIViewController {
         // Get the new view controller using segue.destinationViewController.
         // Pass the selected object to the new view controller.
     }
-    */
-
 }

--- a/BlipsClient/Controllers/AccountOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsTableViewController.swift
@@ -39,5 +39,9 @@ class AccountOptionsTableViewController: UITableViewController, UserAccountObser
             queryOptionsVC.attractionHistoryCount = account.getAttractionHistoryCount()
             queryOptionsVC.queryOptions = account.autoQueryOptions
         }
+        
+        if let savedBlipsVC = segue.destination as? SavedBlipTableViewController {
+            savedBlipsVC.savedBlips = account.savedBlips
+        }
     }
 }

--- a/BlipsClient/Controllers/AccountOptionsViewController.swift
+++ b/BlipsClient/Controllers/AccountOptionsViewController.swift
@@ -1,5 +1,5 @@
 //
-//  StatisticsViewController.swift
+//  AccountOptionsViewController.swift
 //  BlipsClient
 //
 //  Created by Cyrus Sadeghi on 2018-01-27.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class StatisticsViewController: UIViewController {
+class AccountOptionsViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/BlipsClient/Controllers/AccountViewController.swift
+++ b/BlipsClient/Controllers/AccountViewController.swift
@@ -32,7 +32,11 @@ class AccountViewController: UIViewController, UserAccountObserver {
         userSignedIn = false
     }
     
-    func guestReplaced() {
+    func guestReplaced(guestQueried: Bool) {
+        if guestQueried == false {
+            return
+        }
+        
         let alert = UIAlertController(title: "Save Guest History and Options", message: "Do you want to merge your history and options with the guest account's history and options?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in self.signInModel?.mergeGuestHistory() }))
         alert.addAction(UIAlertAction(title: "No", style: .cancel, handler: { _ in return }))

--- a/BlipsClient/Controllers/AccountViewController.swift
+++ b/BlipsClient/Controllers/AccountViewController.swift
@@ -33,7 +33,7 @@ class AccountViewController: UIViewController, UserAccountObserver {
     }
     
     func guestReplaced() {
-        let alert = UIAlertController(title: "Save Guest History", message: "Do you want to merge your history with the guest account's history?", preferredStyle: .alert)
+        let alert = UIAlertController(title: "Save Guest History and Options", message: "Do you want to merge your history and options with the guest account's history and options?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Yes", style: .default, handler: { _ in self.signInModel?.mergeGuestHistory() }))
         alert.addAction(UIAlertAction(title: "No", style: .cancel, handler: { _ in return }))
         self.present(alert, animated: true, completion: nil)

--- a/BlipsClient/Controllers/AccountViewController.swift
+++ b/BlipsClient/Controllers/AccountViewController.swift
@@ -46,7 +46,7 @@ class AccountViewController: UIViewController, UserAccountObserver {
     @IBAction func presentActionSheet(_ sender: UIBarButtonItem) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let clearHistoryAction = UIAlertAction(title: "Clear History", style: .default, handler: { (alert: UIAlertAction!) -> Void in
+        let clearHistoryAction = UIAlertAction(title: "Clear History and Settings", style: .default, handler: { (alert: UIAlertAction!) -> Void in
             self.signInModel?.clearAttractionHistory()
         })
         

--- a/BlipsClient/Controllers/AccountViewController.swift
+++ b/BlipsClient/Controllers/AccountViewController.swift
@@ -81,6 +81,10 @@ class AccountViewController: UIViewController, UserAccountObserver {
             signInModel!.addUserAccountObserver(observer: destinationVC)
         }
         
+        if let optionsVC = segue.destination as? AccountOptionsTableViewController {
+            signInModel!.addUserAccountObserver(observer: optionsVC)
+        }
+        
         super.prepare(for: segue, sender: sender)
     }
 }

--- a/BlipsClient/Controllers/AnywhereUIAlertController.swift
+++ b/BlipsClient/Controllers/AnywhereUIAlertController.swift
@@ -10,12 +10,12 @@ import UIKit
 
 class AnywhereUIAlertController: UIAlertController {
     func show() {
-        let win = UIWindow(frame: UIScreen.main.bounds)
+        /*let win = UIWindow(frame: UIScreen.main.bounds)
         let vc = UIViewController()
         vc.view.backgroundColor = .clear
         win.rootViewController = vc
         win.windowLevel = UIWindowLevelAlert + 1
         win.makeKeyAndVisible()
-        vc.present(self, animated: true, completion: nil)
+        vc.present(self, animated: true, completion: nil)*/
     }
 }

--- a/BlipsClient/Controllers/AttributesTableViewController.swift
+++ b/BlipsClient/Controllers/AttributesTableViewController.swift
@@ -1,4 +1,4 @@
-///
+ ///
 //  AttributesTableViewController.swift
 //  BlipsClient
 //
@@ -11,10 +11,6 @@ import Cosmos
 
 class AttributesTableViewController: UITableViewController {
     @IBOutlet weak var radiusTextField: UITextField!
-    @IBOutlet weak var openNowCell: UITableViewCell!
-    @IBOutlet weak var radiusCell: UITableViewCell!
-    @IBOutlet weak var priceCell: UITableViewCell!
-    @IBOutlet weak var ratingCell: UITableViewCell!
     @IBOutlet weak var starView: CosmosView!
     
     private let defaultRadius = 5000
@@ -28,11 +24,6 @@ class AttributesTableViewController: UITableViewController {
         let tap = UITapGestureRecognizer(target: self.view, action: #selector(UIView.endEditing(_:)))
         tap.cancelsTouchesInView = false
         self.view.addGestureRecognizer(tap)
-        
-        openNowCell.selectionStyle = .none
-        radiusCell.selectionStyle = .none
-        priceCell.selectionStyle = .none
-        ratingCell.selectionStyle = .none
         
         starView.settings.fillMode = .precise
         starView.settings.minTouchRating = 0.0

--- a/BlipsClient/Controllers/BlipDetailViewController.swift
+++ b/BlipsClient/Controllers/BlipDetailViewController.swift
@@ -13,8 +13,11 @@ import Cosmos
 class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource, BlipObserver {
     private var blip: Blip!
     private var blipPageViewController: UIPageViewController?
+    
     var photoIndex: Int!
     var noDescriptionConstraint: NSLayoutConstraint?
+    var observers: [BlipDetailObserver] = [BlipDetailObserver]()
+    var saved = false
 
     @IBOutlet weak var blipTitle: UILabel!
     @IBOutlet weak var blipType: UILabel!
@@ -65,6 +68,10 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
             blipPrice.text = priceText
         }
         
+        if saved {
+            saveButton.setTitle("Unsave", for: .normal)
+        }
+        
         self.view.layoutIfNeeded()
         setupPageControl()
     }
@@ -74,6 +81,10 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
         
         blipDescription.setContentOffset(CGPoint.zero, animated: false)
     }
+    
+    func addObserver(observer: BlipDetailObserver) {
+        observers.append(observer)
+    }
 
     @IBAction func gotoMaps(_ sender: Any) {
         // add ability to save preferred transporation in user account then set it here - will need to pass user pref on class creation
@@ -82,6 +93,19 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
     }
     
     @IBAction func saveBlip(_ sender: UIButton) {
+        if saved {
+            saveButton.setTitle("Save", for: .normal)
+            
+            for observer in observers {
+                observer.blipUnsaved(placeID: blip.placeID)
+            }
+        } else {
+            saveButton.setTitle("Unsave", for: .normal)
+            
+            for observer in observers {
+                observer.blipSaved(blip: blip)
+            }
+        }
     }
 
     func setBlipAnnotation(annotation: BlipMarkerView) {

--- a/BlipsClient/Controllers/BlipDetailViewController.swift
+++ b/BlipsClient/Controllers/BlipDetailViewController.swift
@@ -95,12 +95,14 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
     @IBAction func saveBlip(_ sender: UIButton) {
         if saved {
             saveButton.setTitle("Save", for: .normal)
+            saved = false
             
             for observer in observers {
                 observer.blipUnsaved(placeID: blip.placeID)
             }
         } else {
             saveButton.setTitle("Unsave", for: .normal)
+            saved = true
             
             for observer in observers {
                 observer.blipSaved(blip: blip)

--- a/BlipsClient/Controllers/BlipDetailViewController.swift
+++ b/BlipsClient/Controllers/BlipDetailViewController.swift
@@ -26,6 +26,7 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
     @IBOutlet weak var getDirectionsButton: UIButton!
     @IBOutlet weak var photoViewContainer: UIView!
     @IBOutlet weak var photoViewHeight: NSLayoutConstraint!
+    @IBOutlet weak var saveButton: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,6 +81,9 @@ class BlipDetailViewController: UIViewController, UIPageViewControllerDataSource
         blip.mapItem().openInMaps(launchOptions: launchOptions)
     }
     
+    @IBAction func saveBlip(_ sender: UIButton) {
+    }
+
     func setBlipAnnotation(annotation: BlipMarkerView) {
         self.blip = annotation.blip
     }

--- a/BlipsClient/Controllers/BlipTableToggleButton.swift
+++ b/BlipsClient/Controllers/BlipTableToggleButton.swift
@@ -47,7 +47,7 @@ class BlipTableToggleButton: UIButton, MapModelObserver {
         }
     } 
 
-    func annotationsUpdated(annotations: [MKAnnotation]) {
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType) {
         DispatchQueue.main.async {
             if self.setOriginFrame == false {
                 self.setOriginFrame = true

--- a/BlipsClient/Controllers/BlipTableViewController.swift
+++ b/BlipsClient/Controllers/BlipTableViewController.swift
@@ -35,16 +35,6 @@ class BlipTableViewController: UITableViewController, MapModelObserver {
         self.view.isHidden = false
         self.view.isUserInteractionEnabled = true
     }
-
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return currentBlips.count
-    }
     
     func annotationsUpdated(annotations: [MKAnnotation]) {
         if let asBlips = annotations as? [Blip] {
@@ -65,6 +55,16 @@ class BlipTableViewController: UITableViewController, MapModelObserver {
     func locationUpdated(location: CLLocationCoordinate2D, latitudinalMeters: CLLocationDistance, longitudinalMeters: CLLocationDistance) {}
     func focusOnBlip(blip: Blip) {}
 
+    // MARK: - Table view data source
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return currentBlips.count
+    }
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cellIdentifier = "BlipTableViewCell"
 

--- a/BlipsClient/Controllers/BlipTableViewController.swift
+++ b/BlipsClient/Controllers/BlipTableViewController.swift
@@ -36,7 +36,7 @@ class BlipTableViewController: UITableViewController, MapModelObserver {
         self.view.isUserInteractionEnabled = true
     }
     
-    func annotationsUpdated(annotations: [MKAnnotation]) {
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType) {
         if let asBlips = annotations as? [Blip] {
             self.currentBlips = asBlips
         }

--- a/BlipsClient/Controllers/MapAccessoryView.swift
+++ b/BlipsClient/Controllers/MapAccessoryView.swift
@@ -62,7 +62,7 @@ class MapAccessoryView: UIView, MapModelObserver {
         self.alpha = 0.0
     }
     
-    func annotationsUpdated(annotations: [MKAnnotation]) {
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType) {
         DispatchQueue.main.async {            
             if annotations.count == 0 {
                 self.fadeHideView()

--- a/BlipsClient/Controllers/MapViewController.swift
+++ b/BlipsClient/Controllers/MapViewController.swift
@@ -27,7 +27,7 @@ class MapViewController: MKMapView, MapModelObserver {
 
     // MapModelObserver methods
     
-    func annotationsUpdated(annotations: [MKAnnotation]) {
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType) {
         self.removeAnnotations(myAnnotations)
         self.myAnnotations = annotations
         self.addAnnotations(myAnnotations)

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -1,0 +1,38 @@
+//
+//  QueryOptionsTableViewController.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-23.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import UIKit
+
+class QueryOptionsTableViewController: UITableViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.title = "Autoquery Options"
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 3
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -11,6 +11,7 @@ import Cosmos
 
 class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelegate, UIPickerViewDataSource {
     @IBOutlet weak var attractionTypesToSelect: UITextField!
+    @IBOutlet weak var attractionTypeToSelectLabel: UILabel!
     @IBOutlet weak var autoQueryEnabledSwitch: UISwitch!
     @IBOutlet weak var openNowSwitch: UISwitch!
     @IBOutlet weak var priceRangeControl: UISegmentedControl!
@@ -18,11 +19,7 @@ class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelega
     
     var attractionHistoryCount = 0
     var attractionHistoryCountArray: [String]!
-    var autoQueryEnabled = true
-    var openNow = true
-    var priceRange = 0
-    var rating = 0.0
-    var typeGrabLength = 0
+    var queryOptions: AutoQueryOptions!
     
     var observers = [QueryOptionsObserver]()
     
@@ -51,32 +48,45 @@ class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelega
         starView.settings.minTouchRating = 0.0
         starView.didFinishTouchingCosmos = { rating in self.notifyRatingChanged(newValue: rating) }
         
-        let intArray = Array(1...attractionHistoryCount)
-        attractionHistoryCountArray = intArray.map { String($0) }
+        if attractionHistoryCount == 0 {
+            attractionTypesToSelect.isEnabled = false
+            attractionTypeToSelectLabel.textColor = UIColor.lightGray
+            attractionTypesToSelect.text = ""
+        } else {
+            let intArray = Array(1...attractionHistoryCount)
+            attractionHistoryCountArray = intArray.map { String($0) }
+            
+            attractionTypesToSelect.text = String(queryOptions.autoQueryTypeGrabLength)
+            attractionTypesPicker.selectRow(queryOptions.autoQueryTypeGrabLength - 1, inComponent: 0, animated: false)
+        }
 
         attractionTypesPicker.showsSelectionIndicator = true
         attractionTypesPicker.delegate = self
-                
-        attractionTypesToSelect.text = String(typeGrabLength)
-        autoQueryEnabledSwitch.isOn = autoQueryEnabled
-        openNowSwitch.isOn = openNow
-        priceRangeControl.selectedSegmentIndex = priceRange
-        starView.rating = rating
+        
+        if queryOptions.autoQueryTypeGrabLength == 0 {
+            queryOptions.autoQueryTypeGrabLength = attractionHistoryCount / 2
+            notifyAttractionTypesChanged(newValue: queryOptions.autoQueryTypeGrabLength)
+        }
+        
+        autoQueryEnabledSwitch.isOn = queryOptions.autoQueryEnabled
+        openNowSwitch.isOn = queryOptions.autoQueryOpenNow
+        priceRangeControl.selectedSegmentIndex = queryOptions.autoQueryPriceRange
+        starView.rating = queryOptions.autoQueryRating
     }
 
     @IBAction func autoQueryEnabledChanged(_ sender: UISwitch) {
-        autoQueryEnabled = sender.isOn
-        notifyAutoQueryStatusChanged(newValue: autoQueryEnabled)
+        queryOptions.autoQueryEnabled = sender.isOn
+        notifyAutoQueryStatusChanged(newValue: queryOptions.autoQueryEnabled)
     }
     
     @IBAction func openNowChanged(_ sender: UISwitch) {
-        openNow = sender.isOn
-        notifyOpenNowChanged(newValue: openNow)
+        queryOptions.autoQueryOpenNow = sender.isOn
+        notifyOpenNowChanged(newValue: queryOptions.autoQueryOpenNow)
     }
     
     @IBAction func priceRangeChanged(_ sender: UISegmentedControl) {
-        priceRange = sender.selectedSegmentIndex
-        notifyPriceRangeChanged(newValue: priceRange)
+        queryOptions.autoQueryPriceRange = sender.selectedSegmentIndex
+        notifyPriceRangeChanged(newValue: queryOptions.autoQueryPriceRange)
     }
     
     // MARK: - Observer Updating

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -11,6 +11,9 @@ import Cosmos
 
 class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelegate, UIPickerViewDataSource {
     @IBOutlet weak var attractionTypesToSelect: UITextField!
+    @IBOutlet weak var autoQueryEnabledSwitch: UISwitch!
+    @IBOutlet weak var openNowSwitch: UISwitch!
+    @IBOutlet weak var priceRangeControl: UISegmentedControl!
     @IBOutlet weak var starView: CosmosView!
     
     var attractionHistoryCount = 0
@@ -18,6 +21,8 @@ class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelega
     var autoQueryEnabled = true
     var openNow = true
     var priceRange = 0
+    var rating = 0.0
+    var typeGrabLength = 0
     
     var observers = [QueryOptionsObserver]()
     
@@ -44,12 +49,19 @@ class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelega
         self.title = "Autoquery Options"
         starView.settings.fillMode = .precise
         starView.settings.minTouchRating = 0.0
+        starView.didFinishTouchingCosmos = { rating in self.notifyRatingChanged(newValue: rating) }
         
         let intArray = Array(1...attractionHistoryCount)
         attractionHistoryCountArray = intArray.map { String($0) }
 
         attractionTypesPicker.showsSelectionIndicator = true
         attractionTypesPicker.delegate = self
+                
+        attractionTypesToSelect.text = String(typeGrabLength)
+        autoQueryEnabledSwitch.isOn = autoQueryEnabled
+        openNowSwitch.isOn = openNow
+        priceRangeControl.selectedSegmentIndex = priceRange
+        starView.rating = rating
     }
 
     @IBAction func autoQueryEnabledChanged(_ sender: UISwitch) {
@@ -100,9 +112,6 @@ class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelega
     func notifyPriceRangeChanged(newValue: Int) {
         for observer in observers {
             observer.priceChanged(price: newValue)
-            
-            // Bundle in the rating here
-            observer.ratingChanged(rating: starView.rating)
         }
     }
     

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -7,16 +7,105 @@
 //
 
 import UIKit
+import Cosmos
 
-class QueryOptionsTableViewController: UITableViewController {
-    @IBOutlet weak var attractionTypesField: UILabel!
+class QueryOptionsTableViewController: UITableViewController, UIPickerViewDelegate, UIPickerViewDataSource {
+    @IBOutlet weak var attractionTypesToSelect: UITextField!
+    @IBOutlet weak var starView: CosmosView!
+    
+    var attractionHistoryCount = 0
+    var attractionHistoryCountArray: [String]!
+    var autoQueryEnabled = true
+    var openNow = true
+    var priceRange = 0
+    
+    var observers = [QueryOptionsObserver]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let attractionTypesPicker = UIPickerView()
+        attractionTypesToSelect.inputView = attractionTypesPicker
+        attractionTypesToSelect.tintColor = UIColor.clear
+        
+        let pickerToolbar = UIToolbar()
+        pickerToolbar.barStyle = .default
+        pickerToolbar.isTranslucent = true
+        pickerToolbar.sizeToFit()
+        
+        let doneButton = UIBarButtonItem(title: "Done", style: .plain, target: self, action: #selector(QueryOptionsTableViewController.donePicker))
+        let spaceButton = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let cancelButton = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(QueryOptionsTableViewController.donePicker))
+        
+        pickerToolbar.setItems([cancelButton, spaceButton, doneButton], animated: false)
+        pickerToolbar.isUserInteractionEnabled = true
+        attractionTypesToSelect.inputAccessoryView = pickerToolbar
+        
         self.title = "Autoquery Options"
+        starView.settings.fillMode = .precise
+        starView.settings.minTouchRating = 0.0
+        
+        let intArray = Array(1...attractionHistoryCount)
+        attractionHistoryCountArray = intArray.map { String($0) }
+
+        attractionTypesPicker.showsSelectionIndicator = true
+        attractionTypesPicker.delegate = self
     }
 
+    @IBAction func autoQueryEnabledChanged(_ sender: UISwitch) {
+        autoQueryEnabled = sender.isOn
+        notifyAutoQueryStatusChanged(newValue: autoQueryEnabled)
+    }
+    
+    @IBAction func openNowChanged(_ sender: UISwitch) {
+        openNow = sender.isOn
+        notifyOpenNowChanged(newValue: openNow)
+    }
+    
+    @IBAction func priceRangeChanged(_ sender: UISegmentedControl) {
+        priceRange = sender.selectedSegmentIndex
+        notifyPriceRangeChanged(newValue: priceRange)
+    }
+    
+    // MARK: - Observer Updating
+    
+    func addQueryOptionsObserver(observer: QueryOptionsObserver) {
+        observers.append(observer)
+    }
+    
+    func notifyAttractionTypesChanged(newValue: Int) {
+        for observer in observers {
+            observer.attractionTypesChanged(value: newValue)
+        }
+    }
+    
+    func notifyAutoQueryStatusChanged(newValue: Bool) {
+        for observer in observers {
+            observer.autoQueryStatusChanged(enabled: newValue)
+        }
+    }
+    
+    func notifyOpenNowChanged(newValue: Bool) {
+        for observer in observers {
+            observer.openNowChanged(value: newValue)
+        }
+    }
+    
+    func notifyRatingChanged(newValue: Double) {
+        for observer in observers {
+            observer.ratingChanged(rating: newValue)
+        }
+    }
+    
+    func notifyPriceRangeChanged(newValue: Int) {
+        for observer in observers {
+            observer.priceChanged(price: newValue)
+            
+            // Bundle in the rating here
+            observer.ratingChanged(rating: starView.rating)
+        }
+    }
+    
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -34,14 +123,27 @@ class QueryOptionsTableViewController: UITableViewController {
         return 1
     }
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
+    // MARK: - Picker View
+    
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
     }
-    */
-
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return attractionHistoryCountArray.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return attractionHistoryCountArray[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        attractionTypesToSelect.text = attractionHistoryCountArray[row]
+        notifyAttractionTypesChanged(newValue: Int(attractionHistoryCountArray[row])!)
+    }
+    
+    @objc
+    func donePicker() {
+        attractionTypesToSelect.resignFirstResponder()
+    }
 }

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class QueryOptionsTableViewController: UITableViewController {
+    @IBOutlet weak var attractionTypesField: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/BlipsClient/Controllers/QueryOptionsTableViewController.swift
+++ b/BlipsClient/Controllers/QueryOptionsTableViewController.swift
@@ -22,6 +22,13 @@ class QueryOptionsTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // Section 0 is Automatic Query global enable/disable (currently has 1 row)
+        // Section 1 is Attraction Type number to select (currently has 1 row)
+        // Section 2 is Lookup Attributes (currently has 3 rows)
+        if section == 2 {
+            return 3
+        }
+        
         return 1
     }
 

--- a/BlipsClient/Controllers/SavedBlipTableViewCell.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewCell.swift
@@ -1,0 +1,13 @@
+//
+//  SavedBlipTableViewCell.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-03-01.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import UIKit
+
+class SavedBlipTableViewCell: BlipTableViewCell {
+    @IBOutlet weak var blipCityCountry: UILabel!
+}

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -16,6 +16,8 @@ class SavedBlipTableViewController: UITableViewController {
         super.viewDidLoad()
         
         self.tableView.rowHeight = 44.0
+        self.navigationItem.title = "Saved Blips"
+        self.navigationItem.rightBarButtonItem = self.editButtonItem
     }
     
     func addObserver(observer: SavedBlipTableObserver) {
@@ -66,5 +68,23 @@ class SavedBlipTableViewController: UITableViewController {
         }
         
         return [unsave]
+    }
+    
+    override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
+        return .none
+    }
+    
+    override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+    
+    override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        let movedBlip = self.savedBlips[sourceIndexPath.row]
+        savedBlips.remove(at: sourceIndexPath.row)
+        savedBlips.insert(movedBlip, at: destinationIndexPath.row)
+        
+        for observer in observers {
+            observer.reorderedBlips(sourceRow: sourceIndexPath.row, destinationRow: destinationIndexPath.row)
+        }
     }
 }

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -10,14 +10,24 @@ import UIKit
 
 class SavedBlipTableViewController: UITableViewController {
     var savedBlips: [Blip]!
+    var selectedBlips: [Blip] = [Blip]()
     private var observers = [SavedBlipTableObserver]()
+    private var doneButtonItem: UIBarButtonItem!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        doneButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.doneButtonPressed(sender:)))
+        doneButtonItem.isEnabled = false
+        
+        self.tableView.allowsMultipleSelection = true
         self.tableView.rowHeight = 44.0
         self.navigationItem.title = "Saved Blips"
-        self.navigationItem.rightBarButtonItem = self.editButtonItem
+        self.navigationItem.rightBarButtonItem = doneButtonItem
+    }
+    
+    @objc func doneButtonPressed(sender: UIBarButtonItem) {
+        performSegue(withIdentifier: "querySelectedBlips", sender: self)
     }
     
     func addObserver(observer: SavedBlipTableObserver) {
@@ -47,6 +57,10 @@ class SavedBlipTableViewController: UITableViewController {
         }
         
         let blip = savedBlips[indexPath.row]
+
+        if selectedBlips.contains(blip) {
+            cell.accessoryType = .checkmark
+        }
         
         cell.selectionStyle = .none
         cell.blipName.text = blip.title
@@ -85,6 +99,31 @@ class SavedBlipTableViewController: UITableViewController {
         
         for observer in observers {
             observer.reorderedBlips(sourceRow: sourceIndexPath.row, destinationRow: destinationIndexPath.row)
+        }
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? BlipTableViewCell else {
+            fatalError("Cell wasn't BlipTableViewCell")
+        }
+        
+        cell.accessoryType = .checkmark
+        selectedBlips.append(savedBlips[indexPath.row])
+        
+        doneButtonItem.isEnabled = true
+    }
+    
+    override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) as? BlipTableViewCell else {
+            fatalError("Cell wasn't BlipTableViewCell")
+        }
+        
+        cell.accessoryType = .none
+        let index = selectedBlips.index(of: savedBlips[indexPath.row])
+        selectedBlips.remove(at: index!)
+        
+        if selectedBlips.count == 0 {
+            doneButtonItem.isEnabled = false
         }
     }
 }

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -17,7 +17,7 @@ class SavedBlipTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        doneButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(self.doneButtonPressed(sender:)))
+        doneButtonItem = UIBarButtonItem(title: "Lookup", style: .done, target: self, action: #selector(self.doneButtonPressed(sender:)))
         doneButtonItem.isEnabled = false
         
         self.tableView.allowsMultipleSelection = true
@@ -75,6 +75,11 @@ class SavedBlipTableViewController: UITableViewController {
             let unsavedBlip = self.savedBlips[indexPath.row]
             self.savedBlips.remove(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
+            
+            if self.selectedBlips.contains(unsavedBlip) {
+                let index = self.selectedBlips.index(of: unsavedBlip)
+                self.selectedBlips.remove(at: index!)
+            }
             
             for observer in self.observers {
                 observer.blipUnsaved(blip: unsavedBlip)

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -61,10 +61,10 @@ class SavedBlipTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cellIdentifier = "BlipTableViewCell"
+        let cellIdentifier = "SavedBlipTableViewCell"
         
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? BlipTableViewCell else {
-            fatalError("Dequeued cell wasn't BlipTableViewCell")
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? SavedBlipTableViewCell else {
+            fatalError("Dequeued cell wasn't SavedBlipTableViewCell")
         }
         
         if savedBlips.count == 0 {
@@ -80,6 +80,7 @@ class SavedBlipTableViewController: UITableViewController {
         cell.selectionStyle = .none
         cell.blipName.text = blip.title
         cell.blipType.text = blip.attractionType
+        cell.blipCityCountry.text = blip.city + ", " + blip.country
         cell.typeImage.sd_setImage(with: blip.icon) { (_, _, _, _) in }
         
         return cell
@@ -127,8 +128,8 @@ class SavedBlipTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let cell = tableView.cellForRow(at: indexPath) as? BlipTableViewCell else {
-            fatalError("Cell wasn't BlipTableViewCell")
+        guard let cell = tableView.cellForRow(at: indexPath) as? SavedBlipTableViewCell else {
+            fatalError("Cell wasn't SavedBlipTableViewCell")
         }
         
         cell.accessoryType = .checkmark
@@ -138,8 +139,8 @@ class SavedBlipTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        guard let cell = tableView.cellForRow(at: indexPath) as? BlipTableViewCell else {
-            fatalError("Cell wasn't BlipTableViewCell")
+        guard let cell = tableView.cellForRow(at: indexPath) as? SavedBlipTableViewCell else {
+            fatalError("Cell wasn't SavedBlipTableViewCell")
         }
         
         cell.accessoryType = .none

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -37,7 +37,26 @@ class SavedBlipTableViewController: UITableViewController {
     // MARK: - Table view data source
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        var sections = 0
+        
+        if savedBlips.count != 0 {
+            sections = 1
+            tableView.separatorStyle = .singleLine
+        } else {
+            let noSavedBlipsLabel = UILabel(frame: CGRect(x: 0.0, y: 0.0, width: tableView.bounds.width, height: tableView.bounds.height))
+            let font = UIFontDescriptor(name: "Embrina", size: 30.0)
+            
+            noSavedBlipsLabel.text = "No Saved Blips"
+            noSavedBlipsLabel.textColor = UIColor.lightGray
+            noSavedBlipsLabel.baselineAdjustment = .alignBaselines
+            noSavedBlipsLabel.backgroundColor = UIColor.clear
+            noSavedBlipsLabel.textAlignment = .center
+            noSavedBlipsLabel.font = UIFont(descriptor: font, size: 30.0)
+            tableView.backgroundView = noSavedBlipsLabel
+            tableView.separatorStyle = .none
+        }
+        
+        return sections
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -52,7 +71,6 @@ class SavedBlipTableViewController: UITableViewController {
         }
         
         if savedBlips.count == 0 {
-            //self.hideTableView() - hide table and display background message instead
             return UITableViewCell()
         }
         

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -10,11 +10,16 @@ import UIKit
 
 class SavedBlipTableViewController: UITableViewController {
     var savedBlips: [Blip]!
+    private var observers = [SavedBlipTableObserver]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.tableView.rowHeight = 44.0
+    }
+    
+    func addObserver(observer: SavedBlipTableObserver) {
+        observers.append(observer)
     }
 
     // MARK: - Table view data source
@@ -47,5 +52,19 @@ class SavedBlipTableViewController: UITableViewController {
         cell.typeImage.sd_setImage(with: blip.icon) { (_, _, _, _) in }
         
         return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        let unsave = UITableViewRowAction(style: .destructive, title: "Unsave") { (action, indexPath) in
+            let unsavedBlip = self.savedBlips[indexPath.row]
+            self.savedBlips.remove(at: indexPath.row)
+            tableView.deleteRows(at: [indexPath], with: .fade)
+            
+            for observer in self.observers {
+                observer.blipUnsaved(blip: unsavedBlip)
+            }
+        }
+        
+        return [unsave]
     }
 }

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -1,0 +1,51 @@
+//
+//  SavedBlipTableViewController.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-25.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import UIKit
+
+class SavedBlipTableViewController: UITableViewController {
+    var savedBlips: [Blip]!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.tableView.rowHeight = 44.0
+    }
+
+    // MARK: - Table view data source
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return savedBlips.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cellIdentifier = "BlipTableViewCell"
+        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? BlipTableViewCell else {
+            fatalError("Dequeued cell wasn't BlipTableViewCell")
+        }
+        
+        if savedBlips.count == 0 {
+            //self.hideTableView() - hide table and display background message instead
+            return UITableViewCell()
+        }
+        
+        let blip = savedBlips[indexPath.row]
+        
+        cell.selectionStyle = .none
+        cell.blipName.text = blip.title
+        cell.blipType.text = blip.attractionType
+        cell.typeImage.sd_setImage(with: blip.icon) { (_, _, _, _) in }
+        
+        return cell
+    }
+}

--- a/BlipsClient/Controllers/SavedBlipTableViewController.swift
+++ b/BlipsClient/Controllers/SavedBlipTableViewController.swift
@@ -36,11 +36,8 @@ class SavedBlipTableViewController: UITableViewController {
 
     // MARK: - Table view data source
     
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        var sections = 0
-        
+    override func numberOfSections(in tableView: UITableView) -> Int {        
         if savedBlips.count != 0 {
-            sections = 1
             tableView.separatorStyle = .singleLine
         } else {
             let noSavedBlipsLabel = UILabel(frame: CGRect(x: 0.0, y: 0.0, width: tableView.bounds.width, height: tableView.bounds.height))
@@ -56,7 +53,7 @@ class SavedBlipTableViewController: UITableViewController {
             tableView.separatorStyle = .none
         }
         
-        return sections
+        return 1
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -97,6 +94,10 @@ class SavedBlipTableViewController: UITableViewController {
             if self.selectedBlips.contains(unsavedBlip) {
                 let index = self.selectedBlips.index(of: unsavedBlip)
                 self.selectedBlips.remove(at: index!)
+                
+                if (self.selectedBlips.count == 0) {
+                    self.doneButtonItem.isEnabled = false
+                }
             }
             
             for observer in self.observers {

--- a/BlipsClient/Controllers/SignInViewController.swift
+++ b/BlipsClient/Controllers/SignInViewController.swift
@@ -76,7 +76,7 @@ class SignInViewController: UIViewController, GIDSignInUIDelegate, UserAccountOb
         }
     }
     
-    func guestReplaced() {}
+    func guestReplaced(guestQueried: Bool) {}
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/BlipsClient/Controllers/SignInViewController.swift
+++ b/BlipsClient/Controllers/SignInViewController.swift
@@ -84,8 +84,7 @@ class SignInViewController: UIViewController, GIDSignInUIDelegate, UserAccountOb
         
         if userLoggedIn {
             updateUIOnLogin()
-        }
-        else {
+        } else {
             updateUIOnLogout()
         }
     }

--- a/BlipsClient/Controllers/ViewController.swift
+++ b/BlipsClient/Controllers/ViewController.swift
@@ -206,6 +206,8 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
         }
         
         blipDetailPop?.setBlipAnnotation(annotation: annotation)
+        blipDetailPop?.saved = mainModel.relayBlipSavedStatusCheck(placeID: annotation.blip.placeID)
+        mainModel.relayBlipDetailObserverAddition(detailVC: blipDetailPop!)
         
         self.present(blipDetailPop!, animated: true, completion: nil)
     }

--- a/BlipsClient/Controllers/ViewController.swift
+++ b/BlipsClient/Controllers/ViewController.swift
@@ -220,6 +220,7 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
                 mainModel.clearMapVC(retainAnnotations: true)
                 mainModel.registerLookupVC(lookupVC: lookupVC)
             }
+            
             if let accountVC = destinationNC.topViewController as? AccountViewController {
                 mainModel.registerAccountVC(accountVC: accountVC)
             }
@@ -230,5 +231,7 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
             destinationVC.mainVC = self
             self.blipTableVCasVC = destinationVC
         }
+        
+        super.prepare(for: segue, sender: segue)
     }
 }

--- a/BlipsClient/Controllers/ViewController.swift
+++ b/BlipsClient/Controllers/ViewController.swift
@@ -41,6 +41,10 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
         resizeTableView(percentage: -0.33)
     }
     
+    func relayAPIKeyProvided() {
+        mainModel.relayAPIKeyProvided()
+    }
+    
     func annotationsUpdated(annotations: [MKAnnotation]) {
         let tableView = blipTableVCasVC?.view as! UITableView
         self.blipTableVCYPlacement.constant = 0.0

--- a/BlipsClient/Controllers/ViewController.swift
+++ b/BlipsClient/Controllers/ViewController.swift
@@ -27,6 +27,7 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
     private var maximumTableSize: CGFloat!
     private var safeAreaHeight: CGFloat!
     private var bottomPadding: CGFloat!
+    private var refreshButtonEnabled: Bool = true
 
     func relayUserLogin(account: User) {
         mainModel.relayUserLogin(account: account)
@@ -45,10 +46,17 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
         mainModel.relayAPIKeyProvided()
     }
     
-    func annotationsUpdated(annotations: [MKAnnotation]) {
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType) {
         let tableView = blipTableVCasVC?.view as! UITableView
         self.blipTableVCYPlacement.constant = 0.0
         self.maximumTableSize = 0.0
+        
+        if updateType == UpdateType.SavedBlip {
+            hideRefreshButton()
+            refreshButtonEnabled = false
+        } else {
+            refreshButtonEnabled = true
+        }
         
         if toggleTable.viewsVisible == false {
             toggleTable.viewsVisible = true
@@ -173,7 +181,9 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
     }
     
     func showRefreshButton() {
-        refreshMap.asyncShow()
+        if refreshButtonEnabled {
+            refreshMap.asyncShow()
+        }
     }
     
     func hideRefreshButton() {
@@ -184,6 +194,9 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
     @IBAction func unwindToBlipMap(sender: UIStoryboardSegue) {
         if let sourceViewController = sender.source as? LookupViewController {
             mainModel.relayBlipLookup(lookupVC: sourceViewController)
+        }
+        if let savedBlipsVC = sender.source as? SavedBlipTableViewController {
+            mainModel.relaySavedBlipLookup(savedVC: savedBlipsVC)
         }
         if let _ = sender.source as? AccountViewController {
             mainModel.clearMapVC(retainAnnotations: false)

--- a/BlipsClient/Controllers/ViewController.swift
+++ b/BlipsClient/Controllers/ViewController.swift
@@ -127,7 +127,7 @@ class ViewController: UIViewController, UIPopoverPresentationControllerDelegate,
         self.view.layoutIfNeeded()
         
         if sender.viewsVisible {
-            blipTableVCYPlacement.constant -= (blipTableVC.frame.height + toggleTable.frame.height / 2)
+            blipTableVCYPlacement.constant -= (blipTableVC.frame.height + toggleTable.frame.height / 3)
             blipTableVC.makeInVisible()
             grabberView.makeInVisible()
         } else {

--- a/BlipsClient/Interfaces/BlipDetailObserver.swift
+++ b/BlipsClient/Interfaces/BlipDetailObserver.swift
@@ -1,0 +1,14 @@
+//
+//  BlipDetailObserver.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-24.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import Foundation
+
+protocol BlipDetailObserver {
+    func blipSaved(blip: Blip)
+    func blipUnsaved(placeID: String)
+}

--- a/BlipsClient/Interfaces/MapModelObserver.swift
+++ b/BlipsClient/Interfaces/MapModelObserver.swift
@@ -10,7 +10,7 @@ import Foundation
 import MapKit
 
 protocol MapModelObserver {
-    func annotationsUpdated(annotations: [MKAnnotation])
+    func annotationsUpdated(annotations: [MKAnnotation], updateType: UpdateType)
     func locationUpdated(location: CLLocationCoordinate2D, latitudinalMeters: CLLocationDistance, longitudinalMeters: CLLocationDistance)
     func focusOnBlip(blip: Blip)
 }

--- a/BlipsClient/Interfaces/QueryOptionsObserver.swift
+++ b/BlipsClient/Interfaces/QueryOptionsObserver.swift
@@ -1,0 +1,17 @@
+//
+//  QueryOptionsObserver.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-23.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import Foundation
+
+protocol QueryOptionsObserver {
+    func attractionTypesChanged(value: Int)
+    func autoQueryStatusChanged(enabled: Bool)
+    func openNowChanged(value: Bool)
+    func ratingChanged(rating: Double)
+    func priceChanged(price: Int)
+}

--- a/BlipsClient/Interfaces/SavedBlipTableObserver.swift
+++ b/BlipsClient/Interfaces/SavedBlipTableObserver.swift
@@ -1,0 +1,13 @@
+//
+//  SavedBlipTableObserver.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-25.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import Foundation
+
+protocol SavedBlipTableObserver {
+    func blipUnsaved(blip: Blip)
+}

--- a/BlipsClient/Interfaces/SavedBlipTableObserver.swift
+++ b/BlipsClient/Interfaces/SavedBlipTableObserver.swift
@@ -10,4 +10,5 @@ import Foundation
 
 protocol SavedBlipTableObserver {
     func blipUnsaved(blip: Blip)
+    func reorderedBlips(sourceRow: Int, destinationRow: Int)
 }

--- a/BlipsClient/Interfaces/ServerInterface.swift
+++ b/BlipsClient/Interfaces/ServerInterface.swift
@@ -63,7 +63,7 @@ class ServerInterface {
         } catch ServerInterfaceError.badJSONRequest(description: let error) {
             print(error)
         } catch {
-            print("Other error")
+            print("Generic request failed")
         }
     }
 }

--- a/BlipsClient/Interfaces/UserAccountObserver.swift
+++ b/BlipsClient/Interfaces/UserAccountObserver.swift
@@ -11,5 +11,5 @@ import Foundation
 protocol UserAccountObserver {
     func userLoggedIn(account: User)
     func userLoggedOut()
-    func guestReplaced()
+    func guestReplaced(guestQueried: Bool)
 }

--- a/BlipsClient/Models/AttractionHistory.swift
+++ b/BlipsClient/Models/AttractionHistory.swift
@@ -1,0 +1,26 @@
+//
+//  AttractionHistory.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-23.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import Foundation
+
+struct AttractionHistory: Comparable, Hashable {
+    static func <(lhs: AttractionHistory, rhs: AttractionHistory) -> Bool {
+        return lhs.frequency > rhs.frequency
+    }
+    
+    static func ==(lhs: AttractionHistory, rhs: AttractionHistory) -> Bool {
+        return lhs.attraction == rhs.attraction
+    }
+    
+    var attraction: String
+    let frequency: Int
+    
+    var hashValue: Int {
+        return attraction.hashValue
+    }
+}

--- a/BlipsClient/Models/AutoQueryOptions.swift
+++ b/BlipsClient/Models/AutoQueryOptions.swift
@@ -1,0 +1,45 @@
+//
+//  AutoQueryOptions.swift
+//  BlipsClient
+//
+//  Created by Cyrus Sadeghi on 2018-02-23.
+//  Copyright © 2018 Cyrus Sadeghi. All rights reserved.
+//
+
+import Foundation
+
+class AutoQueryOptions: NSObject, NSCoding {
+    var autoQueryEnabled: Bool
+    var autoQueryTypeGrabLength: Int
+    var autoQueryOpenNow: Bool
+    var autoQueryRating: Double
+    var autoQueryPriceRange: Int
+    
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(autoQueryEnabled, forKey: "autoQueryEnabled")
+        aCoder.encode(autoQueryTypeGrabLength, forKey: "autoQueryTypeGrabLength")
+        aCoder.encode(autoQueryOpenNow, forKey: "autoQueryOpenNow")
+        aCoder.encode(autoQueryRating, forKey: "autoQueryRating")
+        aCoder.encode(autoQueryPriceRange, forKey: "autoQueryPriceRange")
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        self.autoQueryEnabled = aDecoder.decodeBool(forKey: "autoQueryEnabled")
+        self.autoQueryTypeGrabLength = aDecoder.decodeInteger(forKey: "autoQueryTypeGrabLength")
+        self.autoQueryOpenNow = aDecoder.decodeBool(forKey: "autoQueryOpenNow")
+        self.autoQueryRating = aDecoder.decodeDouble(forKey: "autoQueryRating")
+        self.autoQueryPriceRange = aDecoder.decodeInteger(forKey: "autoQueryPriceRange")
+    }
+    
+    init(autoQueryEnabled: Bool, autoQueryTypeGrabLength: Int, autoQueryOpenNow: Bool, autoQueryRating: Double, autoQueryPriceRange: Int) {
+        self.autoQueryEnabled = autoQueryEnabled
+        self.autoQueryTypeGrabLength = autoQueryTypeGrabLength
+        self.autoQueryOpenNow = autoQueryOpenNow
+        self.autoQueryRating = autoQueryRating
+        self.autoQueryPriceRange = autoQueryPriceRange
+    }
+    
+    convenience override init() {
+        self.init(autoQueryEnabled: true, autoQueryTypeGrabLength: 0, autoQueryOpenNow: true, autoQueryRating: 0.0, autoQueryPriceRange: 0)
+    }
+}

--- a/BlipsClient/Models/Blip.swift
+++ b/BlipsClient/Models/Blip.swift
@@ -13,7 +13,7 @@ import GooglePlaces
 // TODO:
 // use GMSPlacesClient to ascertain openNow status
 
-class Blip: NSObject, MKAnnotation {
+class Blip: NSObject, MKAnnotation, NSCoding {
     // Server sends the suffix for the icon (i.e. for a hotel, icon will contain "lodging-71.png")
     static let iconURLPrefix: String = "https://maps.gstatic.com/mapfiles/place_api/icons/"
     
@@ -53,6 +53,20 @@ class Blip: NSObject, MKAnnotation {
         // Force unwrapping this is fine, String contents are set by the time this happens
         self.icon = URL(string: (Blip.iconURLPrefix + iconSuffix))!
         self.information = ""
+    }
+    
+    init(title: String, coordinate: CLLocationCoordinate2D, attractionType: String, rating: Double, price: Int, placeID: String, photos: [UIImage], photoMetadata: [GMSPlacePhotoMetadata], retrievedPhotos: Bool, icon: URL, information: String) {
+        self.title = title
+        self.coordinate = coordinate
+        self.attractionType = attractionType
+        self.rating = rating
+        self.price = price
+        self.placeID = placeID
+        self.photos = photos
+        self.photoMetadata = photoMetadata
+        self.retrievedPhotos = retrievedPhotos
+        self.icon = icon
+        self.information = information
     }
     
     func addObserver(observer: BlipObserver) {
@@ -110,4 +124,38 @@ class Blip: NSObject, MKAnnotation {
     var subtitle: String? {
         return attractionType
     }
+    
+    // NSCoding Methods
+    
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(title, forKey: "title")
+        //aCoder.encode(coordinate, forKey: "coordinate")
+        aCoder.encode(attractionType, forKey: "attractionType")
+        aCoder.encode(rating, forKey: "rating")
+        aCoder.encode(price, forKey: "price")
+        aCoder.encode(placeID, forKey: "placeID")
+        //aCoder.encode(photos, forKey: "photos")
+        //aCoder.encode(photoMetadata, forKey: "photoMetadata")
+        aCoder.encode(retrievedPhotos, forKey: "retrievedPhotos")
+        //aCoder.encode(icon, forKey: "icon")
+        aCoder.encode(information, forKey: "information")
+    }
+    
+    required convenience init?(coder aDecoder: NSCoder) {
+        let name = aDecoder.decodeObject(forKey: "title") as! String
+        //let location = aDecoder.decodeObject(forKey: "coordinate") as! CLLocationCoordinate2D
+        let type = aDecoder.decodeObject(forKey: "attractionType") as! String
+        let blipRating = aDecoder.decodeDouble(forKey: "rating")
+        let blipPrice = aDecoder.decodeInteger(forKey: "price")
+        let id = aDecoder.decodeObject(forKey: "placeID") as! String
+        //let pictures = aDecoder.decodeObject(forKey: "photos") as! [UIImage]
+        //let metadata = aDecoder.decodeObject(forKey: "photoMetadata") as! [GMSPlacePhotoMetadata]
+        let retrieved = aDecoder.decodeBool(forKey: "retrievedPhotos")
+        //let iconURL = aDecoder.decodeObject(forKey: "icon") as! URL
+        let info = aDecoder.decodeObject(forKey: "information") as! String
+        
+        self.init(title: name, coordinate: CLLocationCoordinate2D(), attractionType: type, rating: blipRating, price: blipPrice, placeID: id, photos: [UIImage](), photoMetadata: [GMSPlacePhotoMetadata](), retrievedPhotos: retrieved, icon: URL(string: ".")!, information: info)
+    }
+    
+    // NSCoding Methods end
 }

--- a/BlipsClient/Models/Blip.swift
+++ b/BlipsClient/Models/Blip.swift
@@ -129,32 +129,30 @@ class Blip: NSObject, MKAnnotation, NSCoding {
     
     func encode(with aCoder: NSCoder) {
         aCoder.encode(title, forKey: "title")
-        //aCoder.encode(coordinate, forKey: "coordinate")
+        aCoder.encode(coordinate.latitude, forKey: "latitude")
+        aCoder.encode(coordinate.longitude, forKey: "longitude")
         aCoder.encode(attractionType, forKey: "attractionType")
         aCoder.encode(rating, forKey: "rating")
         aCoder.encode(price, forKey: "price")
         aCoder.encode(placeID, forKey: "placeID")
-        //aCoder.encode(photos, forKey: "photos")
-        //aCoder.encode(photoMetadata, forKey: "photoMetadata")
-        aCoder.encode(retrievedPhotos, forKey: "retrievedPhotos")
-        //aCoder.encode(icon, forKey: "icon")
+        aCoder.encode(icon, forKey: "icon")
         aCoder.encode(information, forKey: "information")
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
         let name = aDecoder.decodeObject(forKey: "title") as! String
-        //let location = aDecoder.decodeObject(forKey: "coordinate") as! CLLocationCoordinate2D
+        let latitude = aDecoder.decodeDouble(forKey: "latitude")
+        let longitude = aDecoder.decodeDouble(forKey: "longitude")
         let type = aDecoder.decodeObject(forKey: "attractionType") as! String
         let blipRating = aDecoder.decodeDouble(forKey: "rating")
         let blipPrice = aDecoder.decodeInteger(forKey: "price")
         let id = aDecoder.decodeObject(forKey: "placeID") as! String
-        //let pictures = aDecoder.decodeObject(forKey: "photos") as! [UIImage]
-        //let metadata = aDecoder.decodeObject(forKey: "photoMetadata") as! [GMSPlacePhotoMetadata]
-        let retrieved = aDecoder.decodeBool(forKey: "retrievedPhotos")
-        //let iconURL = aDecoder.decodeObject(forKey: "icon") as! URL
+        let iconURL = aDecoder.decodeObject(forKey: "icon") as! URL
         let info = aDecoder.decodeObject(forKey: "information") as! String
         
-        self.init(title: name, coordinate: CLLocationCoordinate2D(), attractionType: type, rating: blipRating, price: blipPrice, placeID: id, photos: [UIImage](), photoMetadata: [GMSPlacePhotoMetadata](), retrievedPhotos: retrieved, icon: URL(string: ".")!, information: info)
+        let location = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        
+        self.init(title: name, coordinate: location, attractionType: type, rating: blipRating, price: blipPrice, placeID: id, photos: [UIImage](), photoMetadata: [GMSPlacePhotoMetadata](), retrievedPhotos: false, icon: iconURL, information: info)
     }
     
     // NSCoding Methods end

--- a/BlipsClient/Models/Blip.swift
+++ b/BlipsClient/Models/Blip.swift
@@ -28,6 +28,8 @@ class Blip: NSObject, MKAnnotation, NSCoding {
     var retrievedPhotos: Bool = false
     var icon: URL
     var information: String
+    var city: String
+    var country: String
     
     var observers: [BlipObserver] = []
     
@@ -39,7 +41,9 @@ class Blip: NSObject, MKAnnotation, NSCoding {
         let rating = json["rating"] as? Double,
         let price = json["price"] as? Int,
         let placeID = json["placeID"] as? String,
-        let iconSuffix = json["icon"] as? String
+        let iconSuffix = json["icon"] as? String,
+        let cityName = json["city"] as? String,
+        let countryName = json["country"] as? String
         else {
             return nil
         }
@@ -53,9 +57,11 @@ class Blip: NSObject, MKAnnotation, NSCoding {
         // Force unwrapping this is fine, String contents are set by the time this happens
         self.icon = URL(string: (Blip.iconURLPrefix + iconSuffix))!
         self.information = ""
+        self.city = cityName
+        self.country = countryName
     }
     
-    init(title: String, coordinate: CLLocationCoordinate2D, attractionType: String, rating: Double, price: Int, placeID: String, photos: [UIImage], photoMetadata: [GMSPlacePhotoMetadata], retrievedPhotos: Bool, icon: URL, information: String) {
+    init(title: String, coordinate: CLLocationCoordinate2D, attractionType: String, rating: Double, price: Int, placeID: String, photos: [UIImage], photoMetadata: [GMSPlacePhotoMetadata], retrievedPhotos: Bool, icon: URL, information: String, city: String, country: String) {
         self.title = title
         self.coordinate = coordinate
         self.attractionType = attractionType
@@ -67,6 +73,8 @@ class Blip: NSObject, MKAnnotation, NSCoding {
         self.retrievedPhotos = retrievedPhotos
         self.icon = icon
         self.information = information
+        self.city = city
+        self.country = country
     }
     
     func addObserver(observer: BlipObserver) {
@@ -137,6 +145,8 @@ class Blip: NSObject, MKAnnotation, NSCoding {
         aCoder.encode(placeID, forKey: "placeID")
         aCoder.encode(icon, forKey: "icon")
         aCoder.encode(information, forKey: "information")
+        aCoder.encode(city, forKey: "city")
+        aCoder.encode(country, forKey: "country")
     }
     
     required convenience init?(coder aDecoder: NSCoder) {
@@ -149,10 +159,12 @@ class Blip: NSObject, MKAnnotation, NSCoding {
         let id = aDecoder.decodeObject(forKey: "placeID") as! String
         let iconURL = aDecoder.decodeObject(forKey: "icon") as! URL
         let info = aDecoder.decodeObject(forKey: "information") as! String
+        let cityName = aDecoder.decodeObject(forKey: "city") as! String
+        let countryName = aDecoder.decodeObject(forKey: "country") as! String
         
         let location = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
         
-        self.init(title: name, coordinate: location, attractionType: type, rating: blipRating, price: blipPrice, placeID: id, photos: [UIImage](), photoMetadata: [GMSPlacePhotoMetadata](), retrievedPhotos: false, icon: iconURL, information: info)
+        self.init(title: name, coordinate: location, attractionType: type, rating: blipRating, price: blipPrice, placeID: id, photos: [UIImage](), photoMetadata: [GMSPlacePhotoMetadata](), retrievedPhotos: false, icon: iconURL, information: info, city: cityName, country: countryName)
     }
     
     // NSCoding Methods end

--- a/BlipsClient/Models/LookupModel.swift
+++ b/BlipsClient/Models/LookupModel.swift
@@ -145,7 +145,7 @@ class LookupModel: UserHistoryObserver {
         } catch ServerInterfaceError.JSONParseFailed(description: let error) {
             print(error)
         } catch {
-            print("Other error")
+            print("Attraction Type query failed")
         }
     }
     

--- a/BlipsClient/Models/MainModel.swift
+++ b/BlipsClient/Models/MainModel.swift
@@ -35,7 +35,7 @@ class MainModel {
         accountVC.setSignInModel(signInModel: signInModel)
         signInModel.addUserAccountObserver(observer: accountVC)
     }
-    
+
     // LookupModel Methods
     
     func relayLookupModelObserverAddition(observer: LookupModelObserver) {

--- a/BlipsClient/Models/MainModel.swift
+++ b/BlipsClient/Models/MainModel.swift
@@ -35,6 +35,14 @@ class MainModel {
         accountVC.setSignInModel(signInModel: signInModel)
         signInModel.addUserAccountObserver(observer: accountVC)
     }
+    
+    func relayBlipSavedStatusCheck(placeID: String) -> Bool {
+        return signInModel.userSavedBlip(placeID: placeID)
+    }
+    
+    func relayBlipDetailObserverAddition(detailVC: BlipDetailViewController) {
+        signInModel.connectBlipDetailVC(detailVC: detailVC)
+    }
 
     // LookupModel Methods
     

--- a/BlipsClient/Models/MainModel.swift
+++ b/BlipsClient/Models/MainModel.swift
@@ -105,6 +105,10 @@ class MainModel {
     func setMainVC(vc: ViewController) {
         mapModel.mainVC = vc
     }
+    
+    func relayAPIKeyProvided() {
+        signInModel.apiKeyProvided()
+    }
 
     init() {
         signInModel.setLookupModel(lookupModel: lookupModel)

--- a/BlipsClient/Models/MainModel.swift
+++ b/BlipsClient/Models/MainModel.swift
@@ -57,6 +57,10 @@ class MainModel {
         signInModel.updateAttractionHistory(selections: lookupVC.getSelectedAttractions())
     }
     
+    func relaySavedBlipLookup(savedVC: SavedBlipTableViewController) {
+        mapModel.placeBlips(blips: savedVC.selectedBlips)
+    }
+    
     func registerLookupVC(lookupVC: LookupViewController) {
         // Account needs to know when Attraction Types are available
         // in order to set a prioritized list on app load

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -22,7 +22,6 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
     private var account: User!
     private var haveAnnotations = false
     private var lastQueryLocation: CLLocationCoordinate2D!
-    private var autoQueryEnabled = true
     
     var mainVC: ViewController!
     
@@ -35,7 +34,7 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
         
         self.currentLocation = location
         
-        if autoQueryEnabled == false {
+        if account.autoQueryOptions.autoQueryEnabled == false {
             return
         }
         

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -22,6 +22,7 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
     private var account: User!
     private var haveAnnotations = false
     private var lastQueryLocation: CLLocationCoordinate2D!
+    private var autoQueryEnabled = true
     
     var mainVC: ViewController!
     
@@ -34,6 +35,10 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
         
         self.currentLocation = location
         
+        if autoQueryEnabled == false {
+            return
+        }
+        
         // Center on user location, blips haven't been retrieved yet
         notifyLocationUpdated()
         
@@ -43,8 +48,11 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
         let topTypes = Array(account.orderedAttractionHistory()[0...account.autoQueryTypeGrabLength])
         let topTypesStrings = topTypes.map { $0.attraction }
         
+        // below attributes should come from user account...
         requestBlips(attributes: topTypesStrings, openNow: true, radius: 10000, priceRange: 3, minimumRating: 0.0, latitude: location.latitude, longitude: location.longitude)
     }
+    
+    // LocationObserver Methods end
     
     // UserAccountObserver Methods
     
@@ -65,6 +73,8 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
     
     func guestReplaced() {}
     
+    // UserAccountObserver Methods end
+
     func focusMapOnBlip(blip: Blip) {
         for observer in mapModelObservers {
             observer.focusOnBlip(blip: blip)

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -54,8 +54,7 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
         let topTypes = Array(account.orderedAttractionHistory()[0...(account.autoQueryOptions.autoQueryTypeGrabLength - 1)])
         let topTypesStrings = topTypes.map { $0.attraction }
         
-        // below attributes should come from user account...
-        requestBlips(attributes: topTypesStrings, openNow: true, radius: 10000, priceRange: 3, minimumRating: 0.0, latitude: location.latitude, longitude: location.longitude)
+        requestBlips(attributes: topTypesStrings, openNow: account.autoQueryOptions.autoQueryOpenNow, radius: 10000, priceRange: account.autoQueryOptions.autoQueryPriceRange, minimumRating: account.autoQueryOptions.autoQueryRating, latitude: location.latitude, longitude: location.longitude)
     }
     
     // LocationObserver Methods end

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -135,6 +135,7 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
                 let alert = AnywhereUIAlertController(title: "Blip Display Failed", message: "The server didn't send blips in the correct format.", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
                 alert.show()
+                print("bad blips")
                 
                 return
             }
@@ -158,11 +159,12 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
                 let alert = AnywhereUIAlertController(title: "Query Failed", message: status[0], preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
                 alert.show()
+                print("query failed")
             }
         } catch ServerInterfaceError.JSONParseFailed(description: let error) {
             print(error)
         } catch {
-            print("Other error")
+            print("Blip Query failed")
         }
     }
     

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -39,13 +39,19 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
             return
         }
         
+        if account.autoQueryOptions.autoQueryTypeGrabLength == 0 {
+            // This returns if the account hasn't queried before.
+            // I need to change this to query with a list of "top" attractions from the server
+            return
+        }
+        
         // Center on user location, blips haven't been retrieved yet
         notifyLocationUpdated()
         
         // Initializes MapAccessoryViews on load
         notifyAnnotationsUpdated()
         
-        let topTypes = Array(account.orderedAttractionHistory()[0...account.autoQueryTypeGrabLength])
+        let topTypes = Array(account.orderedAttractionHistory()[0...(account.autoQueryOptions.autoQueryTypeGrabLength - 1)])
         let topTypesStrings = topTypes.map { $0.attraction }
         
         // below attributes should come from user account...

--- a/BlipsClient/Models/MapModel.swift
+++ b/BlipsClient/Models/MapModel.swift
@@ -141,7 +141,6 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
         currentAnnotations.removeAll()
         lastAnnotations.removeAll()
         
-        var blipUnwrapFailed: Bool = false
         
         for entry in serverDict {
             let dictEntry = (entry as NSDictionary).mutableCopy() as! NSMutableDictionary
@@ -150,15 +149,12 @@ class MapModel: NSObject, UserAccountObserver, LocationObserver, MKMapViewDelega
             if let blip = Blip(json: blipEntry) {
                 currentAnnotations.append(blip)
                 blip.requestPhotoMetadata()
-            }
-            else {
-                if blipUnwrapFailed == false {
-                    blipUnwrapFailed = true
-                    
-                    let alert = AnywhereUIAlertController(title: "Blip Display Failed", message: "The server didn't send blips in the correct format.", preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
-                    alert.show()
-                }
+            } else {
+                let alert = AnywhereUIAlertController(title: "Blip Display Failed", message: "The server didn't send blips in the correct format.", preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
+                alert.show()
+                
+                return
             }
         }
         

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -52,7 +52,7 @@ class SignInModel {
         userAccountObservers.append(observer)
         
         if loggedIn == true {
-            notifyUserLoggedIn()
+            observer.userLoggedIn(account: account)
         }
     }
     
@@ -82,6 +82,7 @@ class SignInModel {
     
     func notifyUserLoggedIn() {
         DispatchQueue.main.async {
+            print("async")
             for observer in self.userAccountObservers {
                 observer.userLoggedIn(account: self.account)
             }

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -187,6 +187,12 @@ class SignInModel {
         detailVC.addObserver(observer: account)
     }
     
+    func retrieveSavedBlipMetadata() {
+        for blip in account.savedBlips {
+            blip.requestPhotoMetadata()
+        }
+    }
+    
     func serverLoginCallback(data: Data) {
         do {
             let responseContents = try ServerInterface.readJSON(data: data)

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -227,6 +227,7 @@ class SignInModel {
                     if (status.first != okTag) {
                         let alert = AnywhereUIAlertController(title: "Login Failed", message: "The server rejected your login request.", preferredStyle: .alert);
                         alert.show();
+                        print("bad login")
                         
                         return
                     }
@@ -263,6 +264,7 @@ class SignInModel {
                             default:
                                 let alert = AnywhereUIAlertController(title: "Login Failed", message: "The server returned invalid data.", preferredStyle: .alert);
                                 alert.show();
+                                print("login failed")
                                 
                                 return
                             }
@@ -272,6 +274,7 @@ class SignInModel {
                     if enabledValue == nil || typeGrabLengthValue == nil || openNowValue == nil || ratingValue == nil || priceRangeValue == nil {
                         let alert = AnywhereUIAlertController(title: "Login Failed", message: "The server didn't return all required data.", preferredStyle: .alert);
                         alert.show();
+                        print("login missing data")
                         
                         return
                     }
@@ -287,6 +290,7 @@ class SignInModel {
                             let alert = AnywhereUIAlertController(title: "Blip Retrieval Failed", message: "The server didn't send blips in the correct format.", preferredStyle: .alert)
                             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in }))
                             alert.show()
+                            print("bad blip format")
                             
                             return
                         }
@@ -309,7 +313,7 @@ class SignInModel {
         } catch ServerInterfaceError.JSONParseFailed(description: let error) {
             print(error)
         } catch {
-            print("Other error")
+            print("User login failed")
         }
     }
     
@@ -323,6 +327,7 @@ class SignInModel {
                         if strValue != okTag {
                             let alert = AnywhereUIAlertController(title: "Server Sync Failed", message: "Client information couldn't be synced to the server.", preferredStyle: .alert);
                             alert.show();
+                            print("couldn't sync to server")
                             
                             return
                         }
@@ -332,7 +337,7 @@ class SignInModel {
         } catch ServerInterfaceError.JSONParseFailed(description: let error) {
             print(error)
         } catch {
-            print("Other error")
+            print("Failed to sync to server")
         }
     }
     

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -81,8 +81,10 @@ class SignInModel {
     }
     
     func notifyUserLoggedIn() {
-        for observer in userAccountObservers {
-            observer.userLoggedIn(account: account)
+        DispatchQueue.main.async {
+            for observer in self.userAccountObservers {
+                observer.userLoggedIn(account: self.account)
+            }
         }
     }
     
@@ -131,6 +133,7 @@ class SignInModel {
         
         retrieveSavedBlipMetadata()
         serverLogin()
+        notifyUserLoggedIn()
     }
     
     func userLoggedOut(deleteUser: Bool) {

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -133,7 +133,7 @@ class SignInModel {
             deleteServerUser(id: account.getID())
         }
         
-        self.account.clearAttractionHistory()
+        self.account.clearAttractionHistoryAndSettings()
         self.account = nil
         
         guestUserLogin()
@@ -221,7 +221,7 @@ class SignInModel {
     }
     
     func clearAttractionHistory() {
-        account.clearAttractionHistory()
+        account.clearAttractionHistoryAndSettings()
         
         let jsonRequest = [requestTypeTag: dbSyncTag, syncTypeTag: clearHistoryTag, userIdTag: String(account.getID())]
         

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -99,9 +99,9 @@ class SignInModel {
         }
     }
     
-    func notifyGuestReplaced() {
+    func notifyGuestReplaced(guestQueried: Bool) {
         for observer in userAccountObservers {
-            observer.guestReplaced()
+            observer.guestReplaced(guestQueried: guestQueried)
         }
     }
     
@@ -115,8 +115,14 @@ class SignInModel {
     
     func userLoggedIn(account: User) {
         if loggedIn == true && self.account.isGuest() == true {
+            var guestQueried = false
+            
+            if account.getAttractionHistoryCount() != 0 {
+                guestQueried = true
+            }
+            
             replacedGuest = self.account
-            notifyGuestReplaced()
+            notifyGuestReplaced(guestQueried: guestQueried)
         }
         
         account.signInModel = self
@@ -125,8 +131,6 @@ class SignInModel {
         
         retrieveSavedBlipMetadata()
         serverLogin()
-        
-        notifyUserLoggedIn()
     }
     
     func userLoggedOut(deleteUser: Bool) {
@@ -298,6 +302,7 @@ class SignInModel {
             }
             
             account.setAutoQueryOptions(options: autoQueryOptions)
+            notifyUserLoggedIn()
         } catch ServerInterfaceError.JSONParseFailed(description: let error) {
             print(error)
         } catch {

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -82,7 +82,6 @@ class SignInModel {
     
     func notifyUserLoggedIn() {
         DispatchQueue.main.async {
-            print("async")
             for observer in self.userAccountObservers {
                 observer.userLoggedIn(account: self.account)
             }

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -119,6 +119,7 @@ class SignInModel {
         self.loggedIn = true
         self.account = account
         
+        retrieveSavedBlipMetadata()
         serverLogin()
         
         notifyUserLoggedIn()

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -193,6 +193,10 @@ class SignInModel {
         }
     }
     
+    func apiKeyProvided() {
+        retrieveSavedBlipMetadata()
+    }
+    
     func serverLoginCallback(data: Data) {
         do {
             let responseContents = try ServerInterface.readJSON(data: data)

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -50,7 +50,7 @@ class SignInModel {
     }
     
     func guestUserLogin() {
-        account = User(firstName: "", lastName: "", imageURL: URL(string: ".")!, email: "", userID: -1, attractionHistory: [:], guest: true)
+        account = User()
         
         // lookupModel can be nil here on the app's first ever launch
         // No User info has been saved to disk, so we fall back to a guestLogin,

--- a/BlipsClient/Models/SignInModel.swift
+++ b/BlipsClient/Models/SignInModel.swift
@@ -102,7 +102,7 @@ class SignInModel {
     }
     
     func mergeGuestHistory() {
-        self.account.mergeAttractionHistory(toMerge: self.replacedGuest.getAttractionHistory())
+        self.account.mergeAttractionHistory(toMerge: self.replacedGuest.getAttractionHistory(), savedToMerge: self.replacedGuest.savedBlips)
         self.account.setAutoQueryOptions(options: self.replacedGuest.autoQueryOptions)
         self.setServerHistory(history: self.account.getAttractionHistory())
         self.updateServerAutoQueryOptions(enabled: self.account.autoQueryOptions.autoQueryEnabled, typeGrabLength: self.account.autoQueryOptions.autoQueryTypeGrabLength, openNow: self.account.autoQueryOptions.autoQueryOpenNow, rating: self.account.autoQueryOptions.autoQueryRating, priceRange: self.account.autoQueryOptions.autoQueryPriceRange)
@@ -177,6 +177,14 @@ class SignInModel {
     
     func getAccountID() -> Int {
         return account.getID()
+    }
+    
+    func userSavedBlip(placeID: String) -> Bool {
+        return account.blipIsSaved(placeID: placeID)
+    }
+    
+    func connectBlipDetailVC(detailVC: BlipDetailViewController) {
+        detailVC.addObserver(observer: account)
     }
     
     func serverLoginCallback(data: Data) {

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -307,5 +307,11 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
         saveUser()
     }
     
+    func reorderedBlips(sourceRow: Int, destinationRow: Int) {
+        let movedBlip = self.savedBlips[sourceRow]
+        savedBlips.remove(at: sourceRow)
+        savedBlips.insert(movedBlip, at: destinationRow)
+    }
+    
     // SavedBlipTableObserver Methods end
 }

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -118,6 +118,10 @@ class User: NSObject, NSCoding, LookupModelObserver {
     func getAttractionHistory() -> [String: Int] {
         return attractionHistory
     }
+    
+    func getAttractionHistoryCount() -> Int {
+        return attractionHistory.count
+    }
 
     // NSCoder Persistence methods
     func encode(with aCoder: NSCoder) {

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -36,6 +36,7 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver {
 
     var autoQueryOptions: AutoQueryOptions
     var lastQuery: CustomLookup!
+    var signInModel: SignInModel!
     
     init(firstName: String, lastName: String, imageURL: URL, email: String, userID: Int, attractionHistory: [String: Int], guest: Bool, autoQueryOptions: AutoQueryOptions) {
         self.firstName = firstName
@@ -92,14 +93,6 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver {
     
     func isGuest() -> Bool {
         return guest
-    }
-    
-    func hasMadeRequests() -> Bool {
-        if attractionHistory.count != 0 {
-            return true
-        }
-        
-        return false
     }
     
     func getAttractionHistory() -> [String: Int] {
@@ -238,29 +231,34 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver {
         autoQueryOptions = options
         saveUser()
     }
-    
+
     func attractionTypesChanged(value: Int) {
         autoQueryOptions.autoQueryTypeGrabLength = value
+        signInModel.updateServerAutoQueryOptions(enabled: nil, typeGrabLength: value, openNow: nil, rating: nil, priceRange: nil)
         saveUser()
     }
     
     func autoQueryStatusChanged(enabled: Bool) {
         autoQueryOptions.autoQueryEnabled = enabled
+        signInModel.updateServerAutoQueryOptions(enabled: enabled, typeGrabLength: nil, openNow: nil, rating: nil, priceRange: nil)
         saveUser()
     }
     
     func openNowChanged(value: Bool) {
         autoQueryOptions.autoQueryOpenNow = value
+        signInModel.updateServerAutoQueryOptions(enabled: nil, typeGrabLength: nil, openNow: value, rating: nil, priceRange: nil)
         saveUser()
     }
     
     func ratingChanged(rating: Double) {
         autoQueryOptions.autoQueryRating = rating
+        signInModel.updateServerAutoQueryOptions(enabled: nil, typeGrabLength: nil, openNow: nil, rating: rating, priceRange: nil)
         saveUser()
     }
     
     func priceChanged(price: Int) {
         autoQueryOptions.autoQueryPriceRange = price
+        signInModel.updateServerAutoQueryOptions(enabled: nil, typeGrabLength: nil, openNow: nil, rating: nil, priceRange: price)
         saveUser()
     }
     

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -184,6 +184,16 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver {
                 self.attractionHistory[selection] = 1
             }
         }
+        
+        if autoQueryOptions.autoQueryTypeGrabLength == 0 {
+            if attractionHistory.count > 3 {
+                autoQueryOptions.autoQueryTypeGrabLength = 3
+            } else {
+                autoQueryOptions.autoQueryTypeGrabLength = attractionHistory.count
+            }
+            
+            attractionTypesChanged(value: autoQueryOptions.autoQueryTypeGrabLength)
+        }
 
         updateHistoryListeners()
     }

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -271,6 +271,7 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
     
     func blipSaved(blip: Blip) {
         savedBlips.append(blip)
+        signInModel.serverSaveBlip(blip: blip, save: true)
         saveUser()
     }
     
@@ -279,10 +280,17 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
             if blip.placeID == placeID {
                 if let idx = savedBlips.index(of: blip) {
                     savedBlips.remove(at: idx)
+                    signInModel.serverSaveBlip(blip: blip, save: false)
+                    saveUser()
+                    
+                    return
                 }
             }
         }
-        
+    }
+    
+    func setSavedBlips(savedBlips: [Blip]) {
+        self.savedBlips = savedBlips
         saveUser()
     }
 }

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -21,7 +21,7 @@ struct PropertyKey {
     static let savedBlips = "savedBlips"
 }
 
-class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipDetailObserver {
+class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipDetailObserver, SavedBlipTableObserver {
     static let DocumentsDirectory = FileManager().urls(for: .documentDirectory, in: .userDomainMask).first!
     static let ArchiveURL = DocumentsDirectory.appendingPathComponent("user")
     
@@ -293,4 +293,19 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
         self.savedBlips = savedBlips
         saveUser()
     }
+    
+    // SavedBlipTableObserver Methods
+    
+    func blipUnsaved(blip: Blip) {
+        for loopBlip in savedBlips {
+            if loopBlip.placeID == blip.placeID {
+                savedBlips.remove(at: savedBlips.index(of: loopBlip)!)
+            }
+        }
+        
+        signInModel.serverSaveBlip(blip: blip, save: false)
+        saveUser()
+    }
+    
+    // SavedBlipTableObserver Methods end
 }

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -139,8 +139,6 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
         if isSuccessfulSave == false {
             print("Failed to save user")
         }
-        
-        // need to sync account with server
     }
     
     // User History observer methods
@@ -261,12 +259,6 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
     }
     
     // QueryOptionsObserver Methods end
-    
-    func saveBlip(blip: Blip) {
-        savedBlips.append(blip)
-        saveUser()
-    }
-    
     func blipIsSaved(placeID: String) -> Bool {
         for blip in savedBlips {
             if blip.placeID == placeID {
@@ -279,6 +271,7 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
     
     func blipSaved(blip: Blip) {
         savedBlips.append(blip)
+        saveUser()
     }
     
     func blipUnsaved(placeID: String) {
@@ -289,5 +282,7 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver, BlipD
                 }
             }
         }
+        
+        saveUser()
     }
 }

--- a/BlipsClient/Models/User.swift
+++ b/BlipsClient/Models/User.swift
@@ -234,6 +234,11 @@ class User: NSObject, NSCoding, LookupModelObserver, QueryOptionsObserver {
     
     // QueryOptionsObserver Methods
     
+    func setAutoQueryOptions(options: AutoQueryOptions) {
+        autoQueryOptions = options
+        saveUser()
+    }
+    
     func attractionTypesChanged(value: Int) {
         autoQueryOptions.autoQueryTypeGrabLength = value
         saveUser()


### PR DESCRIPTION
Fixes issue #33 

User auto and refresh queries are now saved server and client side. Whenever the app does an auto query (i.e. on load) or the user requests a manual refresh, the preferences set in their user account are used.

Blips can now be saved to be retrieved later. When a user does a regular lookup, they can open the blip detail view and select a new "Save" button. The blip is then saved into the user account object server side and client side. The new saved blips VC in the account VC allows the user to rearrange, unsave, or remap the saved blips.

Smaller Changes:
- Rewrote server interfacing code to better handle errors and general parsing
- UI bug fixes
- Other small fixes